### PR TITLE
ref chameleon-system/chameleon-system#1: check for existing tags field …

### DIFF
--- a/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1488199875.inc.php
+++ b/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1488199875.inc.php
@@ -1,51 +1,53 @@
 <h1>update - Build #1488199875</h1>
 <h2>Date: 2017-02-27</h2>
 <div class="changelog">
-    media manager tags field<br/>
+    add media manager tags field<br/>
 </div>
 <?php
-$tagsFieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
-$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
-    ->setFields(
-        array(
-            'cms_tbl_conf_id' => TCMSLogChange::GetTableId('cms_media'),
-            'name' => 'cms_tags_mlt',
-            'translation' => 'Tags',
-            'cms_field_type_id' => TCMSLogChange::GetFieldType('CMSFIELD_TAGS'),
-            'cms_tbl_field_tab' => '',
-            'isrequired' => '0',
-            'fieldclass' => '',
-            'fieldclass_subtype' => '',
-            'class_type' => 'Core',
-            'modifier' => 'none',
-            'field_default_value' => '',
-            'length_set' => '',
-            'fieldtype_config' => '',
-            'restrict_to_groups' => '',
-            'field_width' => '',
-            '049_helptext' => '',
-            'row_hexcolor' => '',
-            'is_translatable' => '0',
-            'validation_regex' => '',
-            'id' => $tagsFieldId,
-        )
-    );
-TCMSLogChange::insert(__LINE__, $data);
 
-$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
-    ->setFields(
-        array(
-            'translation' => 'Tags',
-        )
-    )
-    ->setWhereEquals(
-        array(
-            'id' => $tagsFieldId,
-        )
-    );
-TCMSLogChange::update(__LINE__, $data);
+if (false === TCMSLogChange::FieldExists('cms_media','cms_tags_mlt')) {
+    $tagsFieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
+    $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+        ->setFields(
+            array(
+                'cms_tbl_conf_id' => TCMSLogChange::GetTableId('cms_media'),
+                'name' => 'cms_tags_mlt',
+                'translation' => 'Tags',
+                'cms_field_type_id' => TCMSLogChange::GetFieldType('CMSFIELD_TAGS'),
+                'cms_tbl_field_tab' => '',
+                'isrequired' => '0',
+                'fieldclass' => '',
+                'fieldclass_subtype' => '',
+                'class_type' => 'Core',
+                'modifier' => 'none',
+                'field_default_value' => '',
+                'length_set' => '',
+                'fieldtype_config' => '',
+                'restrict_to_groups' => '',
+                'field_width' => '',
+                '049_helptext' => '',
+                'row_hexcolor' => '',
+                'is_translatable' => '0',
+                'validation_regex' => '',
+                'id' => $tagsFieldId,
+            )
+        );
+    TCMSLogChange::insert(__LINE__, $data);
 
-$query = "CREATE TABLE `cms_media_cms_tags_mlt` (
+    $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+        ->setFields(
+            array(
+                'translation' => 'Tags',
+            )
+        )
+        ->setWhereEquals(
+            array(
+                'id' => $tagsFieldId,
+            )
+        );
+    TCMSLogChange::update(__LINE__, $data);
+
+    $query = "CREATE TABLE `cms_media_cms_tags_mlt` (
                   `source_id` CHAR( 36 ) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL ,
                   `target_id` CHAR( 36 ) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL ,
                   `entry_sort` int(11) NOT NULL default '0',
@@ -53,6 +55,7 @@ $query = "CREATE TABLE `cms_media_cms_tags_mlt` (
                   INDEX (target_id),
                   INDEX (entry_sort)
                 )";
-TCMSLogChange::RunQuery(__LINE__, $query);
+    TCMSLogChange::RunQuery(__LINE__, $query);
 
-TCMSLogChange::SetFieldPosition(TCMSLogChange::GetTableId('cms_media'), 'cms_tags_mlt', 'filetypes');
+    TCMSLogChange::SetFieldPosition(TCMSLogChange::GetTableId('cms_media'), 'cms_tags_mlt', 'filetypes');
+}

--- a/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1488199875.inc.php
+++ b/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1488199875.inc.php
@@ -5,7 +5,7 @@
 </div>
 <?php
 
-if (false === TCMSLogChange::FieldExists('cms_media','cms_tags_mlt')) {
+if (false === TCMSLogChange::FieldExists('cms_media', 'cms_tags_mlt')) {
     $tagsFieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
     $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
         ->setFields(


### PR DESCRIPTION
…in cms_media table

| Q             | A
| ------------- | ---
| Branch?       | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed issues  | #1
| License       | MIT

setup update file now checks for existing tags field in cms_media table to prevent duplicate