### PR TITLE
chameleon-system/chameleon-system#24: add german translations for cms_media.alt_tag and cms_media.systemname

### DIFF
--- a/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1534346712.inc.php
+++ b/src/MediaManagerBundle/Bridge/Chameleon/Migration/Script/update-1534346712.inc.php
@@ -1,0 +1,35 @@
+<h1>Build #1534346712</h1>
+<h2>Date: 2018-08-15</h2>
+<div class="changelog">
+    - add German translations for cms_media.alt_tag and cms_media.systemname
+</div>
+<?php
+$cmsMediaTableId = TCMSLogChange::GetTableId('cms_media');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields(
+        array(
+            'translation' => 'Alt Tag',
+        )
+    )
+    ->setWhereEquals(
+        array(
+            'cms_tbl_conf_id' => $cmsMediaTableId,
+            'name' => 'alt_tag',
+        )
+    );
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields(
+        array(
+            'translation' => 'Systemname',
+        )
+    )
+    ->setWhereEquals(
+        array(
+            'cms_tbl_conf_id' => $cmsMediaTableId,
+            'name' => 'systemname',
+        )
+    );
+TCMSLogChange::update(__LINE__, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-syste#24
| License       | MIT