### PR TITLE
ref #31: ref #38: Re-add backend list cache

### DIFF
--- a/src/CoreBundle/Resources/config/defaults.inc.php
+++ b/src/CoreBundle/Resources/config/defaults.inc.php
@@ -967,7 +967,7 @@ if (!defined('CMS_ACTIVE_BACKEND_LIST_CACHE')) {
     /**
      * @deprecated since 6.2.0 - no longer used.
      */
-    define('CMS_ACTIVE_BACKEND_LIST_CACHE', false);
+    define('CMS_ACTIVE_BACKEND_LIST_CACHE', true);
 }
 
 /**

--- a/src/CoreBundle/Resources/config/defaults.inc.php
+++ b/src/CoreBundle/Resources/config/defaults.inc.php
@@ -965,7 +965,7 @@ if (!defined('CMS_SEARCH_INDEX_USE_LOAD_FILE')) {
 */
 if (!defined('CMS_ACTIVE_BACKEND_LIST_CACHE')) {
     /**
-     * @deprecated since 6.2.0 - no longer used.
+     * @deprecated since 6.2.0 - list caching will be removed in any later Chameleon version.
      */
     define('CMS_ACTIVE_BACKEND_LIST_CACHE', true);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#31, chameleon-system/chameleon-system#38
| License       | MIT

Removing the session-based cache from backend lists caused two issues (see links above). I think removing the cache is still a good decision although we overlooked the consequences, so we should think about better solutions (sorting and state-saving are only side effects of the session-based cache). Until then we should restore the code used in Chameleon < 6.2.0.

We could also hold this PR back until the end of the current sprint in case we find a better solution, but we definitely want the problems solved in the September milestone.