### PR TITLE
ref #44: Improve configuration of TransformOutgoingMailTargetsService

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -1,0 +1,54 @@
+UPGRADE FROM 6.2 TO 6.3
+=======================
+
+# Deprecated Code Entities
+
+It is recommended that all references to the classes, interfaces, properties, constants, methods and services in the
+following list are removed from the project, as they will be removed in Chameleon 7.0. The deprecation notices in the
+code will tell if there are replacements for the deprecated entities or if the functionality is to be entirely removed.
+
+To search for deprecated code usage, [SensioLabs deprecation detector](https://github.com/sensiolabs-de/deprecation-detector)
+is recommended (although this tool may not find database-related deprecations).
+
+## Services
+
+None.
+
+## Container Parameters
+
+None.
+
+## Constants
+
+None.
+
+## Classes and Interfaces
+
+None.
+
+## Properties
+
+None.
+
+## Methods
+
+- \ChameleonSystem\CoreBundle\Interfaces\TransformOutgoingMailTargetsServiceInterface::setEnableTransformation()
+- \ChameleonSystem\CoreBundle\Interfaces\TransformOutgoingMailTargetsServiceInterface::setSubjectPrefix()
+- \ChameleonSystem\CoreBundle\Service\TransformOutgoingMailTargetsService::setEnableTransformation()
+- \ChameleonSystem\CoreBundle\Service\TransformOutgoingMailTargetsService::setSubjectPrefix()
+
+## JavaScript Files and Functions
+
+None.
+
+## Translations
+
+None.
+
+## Database Tables
+
+None.
+
+## Database Fields
+
+None.

--- a/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
+++ b/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
@@ -83,6 +83,12 @@ class ChameleonSystemCoreExtension extends Extension
         foreach ($config as $key => $value) {
             $container->setParameter("chameleon_system_core.mail_target_transformation_service.$key", $value);
         }
+
+        if (true === $config['enabled']) {
+            $container->setAlias('chameleon_system_core.mail_target_transformation_service', 'chameleon_system_core.transforming_mail_target_transformation_service');
+        } else {
+            $container->setAlias('chameleon_system_core.mail_target_transformation_service', 'chameleon_system_core.null_mail_target_transformation_service');
+        }
     }
 
     /**

--- a/src/CoreBundle/Interfaces/TransformOutgoingMailTargetsServiceInterface.php
+++ b/src/CoreBundle/Interfaces/TransformOutgoingMailTargetsServiceInterface.php
@@ -14,13 +14,15 @@ namespace ChameleonSystem\CoreBundle\Interfaces;
 interface TransformOutgoingMailTargetsServiceInterface
 {
     /**
-     * @param $enableTransformation
+     * @param bool $enableTransformation
      *
-     * @return mixed
+     * @deprecated since 6.3.0 - no longer used. Transformation is enabled/disabled by ChameleonSystemCoreExtension.
      */
     public function setEnableTransformation($enableTransformation);
 
     /**
+     * Returns an alternative email address for the passed email address (this may be the same one).
+     *
      * @param string $mail
      *
      * @return string
@@ -28,11 +30,18 @@ interface TransformOutgoingMailTargetsServiceInterface
     public function transform($mail);
 
     /**
+     * Returns a modified email subject.
+     *
      * @param string $subject
      *
      * @return string
      */
     public function transformSubject($subject);
 
+    /**
+     * @param string $prefix
+     *
+     * @deprecated since 6.3.0 - it is now up to the implementation how the prefix is managed.
+     */
     public function setSubjectPrefix($prefix);
 }

--- a/src/CoreBundle/Resources/config/mail.xml
+++ b/src/CoreBundle/Resources/config/mail.xml
@@ -17,16 +17,16 @@
 
         <service id="chameleon_system_core.phpmailer" class="TCMSMail" shared="false" />
 
-        <service id="chameleon_system_core.mail_target_transformation_service" class="ChameleonSystem\CoreBundle\Service\TransformOutgoingMailTargetsService" public="false">
+        <service id="chameleon_system_core.mail_target_transformation_service" alias="chameleon_system_core.null_mail_target_transformation_service" />
+
+        <service id="chameleon_system_core.transforming_mail_target_transformation_service" class="ChameleonSystem\CoreBundle\Service\TransformOutgoingMailTargetsService" public="false">
             <argument>%chameleon_system_core.mail_target_transformation_service.target_mail%</argument>
             <argument>%chameleon_system_core.mail_target_transformation_service.white_list%</argument>
             <argument type="service" id="chameleon_system_core.portal_domain_service" />
-            <call method="setEnableTransformation">
-                <argument>%chameleon_system_core.mail_target_transformation_service.enabled%</argument>
-            </call>
-            <call method="setSubjectPrefix">
-                <argument>%chameleon_system_core.mail_target_transformation_service.subject_prefix%</argument>
-            </call>
+            <argument>%chameleon_system_core.mail_target_transformation_service.subject_prefix%</argument>
+        </service>
+
+        <service id="chameleon_system_core.null_mail_target_transformation_service" class="ChameleonSystem\CoreBundle\Service\NullOutgoingMailTargetsService">
         </service>
 
         <service id="chameleon_system_core.security.mail.strict_mail_peer_security" class="ChameleonSystem\CoreBundle\Security\Https\StrictHttpsContext" />

--- a/src/CoreBundle/Service/NullOutgoingMailTargetsService.php
+++ b/src/CoreBundle/Service/NullOutgoingMailTargetsService.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\CoreBundle\Service;
+
+use ChameleonSystem\CoreBundle\Interfaces\TransformOutgoingMailTargetsServiceInterface;
+
+class NullOutgoingMailTargetsService implements TransformOutgoingMailTargetsServiceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setEnableTransformation($enableTransformation)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($mail)
+    {
+        return $mail;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transformSubject($subject)
+    {
+        return $subject;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSubjectPrefix($prefix)
+    {
+    }
+}

--- a/src/CoreBundle/Service/TransformOutgoingMailTargetsService.php
+++ b/src/CoreBundle/Service/TransformOutgoingMailTargetsService.php
@@ -18,7 +18,7 @@ class TransformOutgoingMailTargetsService implements TransformOutgoingMailTarget
     /**
      * @var bool
      */
-    private $enableTransformation = false;
+    private $enableTransformation = true;
     /**
      * @var PortalDomainServiceInterface
      */
@@ -48,16 +48,22 @@ class TransformOutgoingMailTargetsService implements TransformOutgoingMailTarget
      * @param string                       $transformationTarget
      * @param string                       $whiteList
      * @param PortalDomainServiceInterface $portalDomainService
+     * @param string                       $subjectPrefix
      */
-    public function __construct($transformationTarget, $whiteList, PortalDomainServiceInterface $portalDomainService)
+    public function __construct($transformationTarget, $whiteList, PortalDomainServiceInterface $portalDomainService, $subjectPrefix)
     {
-        $this->portalDomainService = $portalDomainService;
         $this->transformationTarget = $transformationTarget;
         $this->extractWhiteList($whiteList);
+        $this->portalDomainService = $portalDomainService;
+        $this->subjectPrefix = $subjectPrefix;
     }
 
     /**
-     * @param bool $enableTransformation
+     * {@inheritdoc}
+     *
+     * @deprecated since 6.3.0 - see deprecation note in interface. This implementation is now active by default
+     *             and should simply not be called if it should not be used (e.g. by using NullOutgoingMailTargetsService
+     *             instead). If deactivated by calling this method, the email subject will still be prefixed.
      */
     public function setEnableTransformation($enableTransformation)
     {
@@ -65,7 +71,9 @@ class TransformOutgoingMailTargetsService implements TransformOutgoingMailTarget
     }
 
     /**
-     * @param string $prefix
+     * {@inheritdoc}
+     *
+     * @deprecated since 6.3.0 - use constructor injection instead.
      */
     public function setSubjectPrefix($prefix)
     {
@@ -73,9 +81,7 @@ class TransformOutgoingMailTargetsService implements TransformOutgoingMailTarget
     }
 
     /**
-     * @param string $mail
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function transform($mail)
     {
@@ -91,9 +97,7 @@ class TransformOutgoingMailTargetsService implements TransformOutgoingMailTarget
     }
 
     /**
-     * @param string $subject
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function transformSubject($subject)
     {

--- a/src/CoreBundle/Tests/Service/TransformOutgoingMailTargetsServiceTest.php
+++ b/src/CoreBundle/Tests/Service/TransformOutgoingMailTargetsServiceTest.php
@@ -18,20 +18,41 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 class TransformOutgoingMailTargetsServiceTest extends TestCase
 {
+    /**
+     * @var string
+     */
     private $targetMail;
+    /**
+     * @var array
+     */
     private $whiteList;
     /**
-     * @var PortalDomainServiceInterface
+     * @var PortalDomainServiceInterface|ObjectProphecy
      */
     private $portalDomainService;
     /**
      * @var TransformOutgoingMailTargetsService
      */
     private $service;
+    /**
+     * @var string
+     */
     private $transformedMail;
+    /**
+     * @var string
+     */
     private $inputMail;
+    /**
+     * @var string
+     */
     private $subjectPrefix;
+    /**
+     * @var string
+     */
     private $transformedSubject;
+    /**
+     * @var string
+     */
     private $sourceSubject;
 
     protected function tearDown()
@@ -98,15 +119,13 @@ class TransformOutgoingMailTargetsServiceTest extends TestCase
 
     private function given_an_instance_of_the_service()
     {
-        $this->service = new TransformOutgoingMailTargetsService($this->targetMail, $this->whiteList, $this->portalDomainService);
-        $this->service->setEnableTransformation(true);
-        $this->service->setSubjectPrefix($this->subjectPrefix);
+        $this->service = new TransformOutgoingMailTargetsService($this->targetMail, $this->whiteList, $this->portalDomainService, $this->subjectPrefix);
     }
 
     private function given_that_the_active_portal_has_the_following_domains($domainList)
     {
         /** @var $portalDomainService PortalDomainServiceInterface|ObjectProphecy */
-        $portalDomainService = $this->prophesize('ChameleonSystem\CoreBundle\Service\PortalDomainServiceInterface');
+        $portalDomainService = $this->prophesize(PortalDomainServiceInterface::class);
         $portalDomainService->getDomainNameList()->willReturn($domainList);
         $this->portalDomainService = $portalDomainService->reveal();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#44
| License       | MIT

A fix but with deprecations, therefore targets 6.3. This PR improves how the mail target transformation handles its enabled state - by not handling it at all, but leaving the decision to infrastructure code.