### PR TITLE
ref #61: Import multiselect field functions to download field

### DIFF
--- a/CHANGELOG-7.1.md
+++ b/CHANGELOG-7.1.md
@@ -4,3 +4,7 @@ CHANGELOG For 7.1.x
 # New Features
 
 # Changed Features
+
+## Field Type "Document manager" extends `TCMSFieldLookupMultiselect`
+
+This changes public methods - especially `GetMLTTableName`.

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
@@ -46,3 +46,44 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
   ])
 ;
 TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'de')
+    ->setFields([
+        'help_text' => '<div class="field-name"><strong>Feldname:</strong> beliebig</div>
+
+<div class="php-class"><strong>PHP Klasse:</strong> TCMSFieldDownloads extends TCMSFieldLookupMultiselect</div>
+
+<div>Erzeugt einen Button, der das Verbinden mehrerer Dokumente mit dem Datensatz ermöglicht.</div>
+
+<div>Die Dokumente müssen vorher über den Dokumenten-Manager hochgeladen werden.</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Pflicht-Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optionale Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter optional">n/a</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+    ])
+    ->setWhereEquals([
+        'fieldclass' => 'TCMSFieldDownloads',
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
@@ -1,0 +1,49 @@
+<h1>Build #1538989279</h1>
+<h2>Date: 2018-10-08</h2>
+<div class="changelog">
+    - #61: Change type and help text (correct super class)
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
+  ->setFields([
+      'base_type' => 'mlt',
+      'help_text' => '<div class="field-name"><strong>Field name:</strong>&nbsp;any</div>
+
+<div class="php-class"><strong>PHP class:</strong> TCMSFieldDownloads extends TCMSFieldLookupMultiselect</div>
+
+<div>Creates a button that allows several&nbsp;documents to be linked to the record.</div>
+
+<div>The documents must be uploaded via the document manager before.</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Required parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optional&nbsp;parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter optional">n/a</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+  ])
+  ->setWhereEquals([
+      'fieldclass' => 'TCMSFieldDownloads',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1538989279.inc.php
@@ -46,4 +46,3 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
   ])
 ;
 TCMSLogChange::update(__LINE__, $data);
-

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
@@ -157,9 +157,7 @@ class TCMSFieldDownloads extends TCMSFieldLookupMultiselect
     }
 
     /**
-     * @param array $aFieldData sql field data
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function GetMLTTableName($aFieldData = [])
     {
@@ -174,13 +172,16 @@ class TCMSFieldDownloads extends TCMSFieldLookupMultiselect
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function GetConnectedTableName($bExistingCount = true)
     {
         return $this->GetMLTTableName();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function GetConnectedTableNameFromSQLData($aNewFieldData)
     {
         return $this->GetMLTTableName($aNewFieldData);

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
@@ -153,6 +153,15 @@ class TCMSFieldDownloads extends TCMSFieldLookupMultiselect
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getConnectedTableNameFromDefinition(): ?string
+    {
+        return $this->GetForeignTableName();
+    }
+
+
+    /**
      * Get an array of either posted data or data from db if nothings has been posted.
      *
      * @return array

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
@@ -14,7 +14,7 @@ use ChameleonSystem\DatabaseMigration\DataModel\LogChangeDataModel;
 /****************************************************************************
  * Download files
 /***************************************************************************/
-class TCMSFieldDownloads extends TCMSMLTField
+class TCMSFieldDownloads extends TCMSFieldLookupMultiselect
 {
     protected $oTableConf = null;
 
@@ -157,13 +157,15 @@ class TCMSFieldDownloads extends TCMSMLTField
     }
 
     /**
-     * returns the mlt table name.
+     * @param array $aFieldData sql field data
      *
      * @return string
      */
-    public function GetMLTTableName()
+    public function GetMLTTableName($aFieldData = [])
     {
-        return $this->sTableName.'_'.$this->name.'_cms_document_mlt';
+        $name = $aFieldData['name'] ?? $this->name; 
+        
+        return $this->sTableName.'_'.$name.'_cms_document_mlt';
     }
 
     public function GetForeignTableName()
@@ -176,7 +178,12 @@ class TCMSFieldDownloads extends TCMSMLTField
      */
     public function GetConnectedTableName($bExistingCount = true)
     {
-        return 'cms_document';
+        return $this->GetMLTTableName();
+    }
+
+    protected function GetConnectedTableNameFromSQLData($aNewFieldData)
+    {
+        return $this->GetMLTTableName($aNewFieldData);
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDownloads.class.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use ChameleonSystem\DatabaseMigration\DataModel\LogChangeDataModel;
-
 /****************************************************************************
  * Download files
 /***************************************************************************/
@@ -159,7 +157,6 @@ class TCMSFieldDownloads extends TCMSFieldLookupMultiselect
     {
         return $this->GetForeignTableName();
     }
-
 
     /**
      * Get an array of either posted data or data from db if nothings has been posted.

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldLookupMultiselect.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldLookupMultiselect.class.php
@@ -201,7 +201,7 @@ class TCMSFieldLookupMultiselect extends TCMSMLTField
             $sConnectedTableName = $this->GetConnectedTableNameFromFieldConfig($aFieldData);
             $sName = $aFieldData['name'];
         } else {
-            $sConnectedTableName = $this->oDefinition->GetFieldtypeConfigKey('connectedTableName');
+            $sConnectedTableName = $this->getConnectedTableNameFromDefinition();
             $sName = $this->name;
         }
         if ($sConnectedTableName) {
@@ -214,6 +214,11 @@ class TCMSFieldLookupMultiselect extends TCMSMLTField
         }
 
         return $mltTableName;
+    }
+
+    protected function getConnectedTableNameFromDefinition(): ?string
+    {
+        return $this->oDefinition->GetFieldtypeConfigKey('connectedTableName');
     }
 
     /**
@@ -291,7 +296,7 @@ class TCMSFieldLookupMultiselect extends TCMSMLTField
         $bAllowRenameRelatedTables = false;
         if ('mlt' == $aOldFieldTypeRow['base_type'] && 'mlt' == $aNewFieldTypeRow['base_type']) {
             $sFieldConfigConnectedTableForNewField = $this->GetConnectedTableNameFromFieldConfig($aNewFieldData);
-            $sFieldConfigConnectedTableForOldField = $this->oDefinition->GetFieldtypeConfigKey('connectedTableName');
+            $sFieldConfigConnectedTableForOldField = $this->getConnectedTableNameFromDefinition();
             if (!empty($sFieldConfigConnectedTableForNewField) && !empty($sFieldConfigConnectedTableForOldField)) {
                 if ($sFieldConfigConnectedTableForNewField == $sFieldConfigConnectedTableForOldField && $this->name != $aNewFieldData['name']) {
                     $bAllowRenameRelatedTables = true;
@@ -340,7 +345,7 @@ class TCMSFieldLookupMultiselect extends TCMSMLTField
      */
     public function GetConnectedTableName($bExistingCount = true)
     {
-        $sTableName = $this->oDefinition->GetFieldtypeConfigKey('connectedTableName');
+        $sTableName = $this->getConnectedTableNameFromDefinition();
 
         return $this->GetClearedTableName($sTableName);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#61
| License       | MIT

Use TCMSFieldLookupMultiselect as a base (+ minor adjustments) which has the logic to only delete the MLT if needed.

One problem remains: When you actually rename the field itself the MLT is still dropped (instead of the mlt be moved).