### PR TITLE
ref #67: Make minimum password length configurable

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1536569343.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1536569343.inc.php
@@ -1,0 +1,12 @@
+<h1>Build #1536569343</h1>
+<h2>Date: 2018-09-10</h2>
+<div class="changelog">
+    - Add backend messages for password validation
+</div>
+<?php
+
+TCMSLogChange::AddBackEndMessage('TABLEEDITOR_FIELD_PASSWORD_TOO_SHORT', 'The password in field "[{sFieldTitle:string}]" is too short. Minimum length is [{min}].', '4', 'Password too short.', 'en');
+TCMSLogChange::AddBackEndMessage('TABLEEDITOR_FIELD_PASSWORD_TOO_SHORT', 'Das Passwort im Feld "[{sFieldTitle:string}]" ist zu kurz. Bitte mindestens [{min}] Zeichen vergeben.', '4', 'Passwort zu kurz.', 'de');
+
+TCMSLogChange::AddBackEndMessage('TABLEEDITOR_FIELD_PASSWORD_TOO_LONG', 'The password in field "[{sFieldTitle:string}]" is too long. Maximum length is [{max}].', '4', 'Password too long.', 'en');
+TCMSLogChange::AddBackEndMessage('TABLEEDITOR_FIELD_PASSWORD_TOO_LONG', 'Das Passwort in Feld "[{sFieldTitle:string}]" ist zu lang. Bitte höchstens [{max}] Zeichen vergeben.', '4', 'Passwort zu lang.', 'de');

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1536581717.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1536581717.inc.php
@@ -1,0 +1,204 @@
+<h1>Build #1536581717</h1>
+<h2>Date: 2018-09-10</h2>
+<div class="changelog">
+    - Configure minimum password length
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
+  ->setFields([
+      '049_trans' => 'Password (cleartext)',
+      'help_text' => '<div class="field-name"><strong>Field name:</strong>&nbsp;any</div>
+
+<div class="php-class"><strong>PHP class:</strong> TCMSFieldPassword extends TCMSFieldVarchar</div>
+
+<div>Creates two text fields for password and password repetition. Besides, a&nbsp;display indicates the quality (security) of the password.</div>
+
+<div>Furthermore, the field indicates whether a password has already been entered or not.</div>
+
+<div>&nbsp;</div>
+
+<div class="important"><strong>Important:</strong>&nbsp;The password is stored in cleartext form&nbsp;in the database! In almost all cases it makes more sense to use the field "Password (secure)"</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Required parameters:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optional&nbsp;parameters:</li>
+	<li>
+	<ul>
+		<li class="parameter optional"><strong>minimumLength=Number</strong> - the minimum number of characters for the field (default 6).</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+  ])
+  ->setWhereEquals([
+      'constname' => 'CMSFIELD_PASSWORD',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'de')
+    ->setFields([
+        '049_trans' => 'Passwort (Klartext)',
+        'help_text' => '<div class="field-name"><strong>Feldname:</strong> beliebig</div>
+
+<div class="php-class"><strong>PHP Klasse:</strong> TCMSFieldPassword extends TCMSFieldVarchar</div>
+
+<div>Erzeugt zwei Textfelder für Passwort und Passwort-Wiederholung. Außerdem wird ein Indikator für die Passwort-Qualität dargestellt.</div>
+
+<div>Das Feld zeigt zusätzlich an, ob bereits ein Passwort hinterlegt ist oder nicht.</div>
+
+<div>&nbsp;</div>
+
+<div class="important"><strong>Wichtig:</strong> Das Passwort wird im Klartext in der Datenbank gespeichert! In praktisch allen Fällen ist es sinnvoller, das Feld "Passwort (sicher)" zu verwenden.</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Pflicht-Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optionale Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter optional"><strong>minimumLength=Zahl</strong> - die minimale Zeichenzahl für das Feld (Standard 6).</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+    ])
+    ->setWhereEquals([
+        'constname' => 'CMSFIELD_PASSWORD',
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
+  ->setFields([
+      '049_trans' => 'Password (secure)',
+      'help_text' => '<div class="field-name"><strong>Field name:</strong>&nbsp;any</div>
+
+<div class="php-class"><strong>PHP class:</strong> TCMSFieldPasswordEncrypted extends TCMSFieldPassword</div>
+
+<div>Creates two text fields for password and password repetition. Besides, a&nbsp;display indicates the quality (security) of the password.</div>
+
+<div>Furthermore, the field indicates whether a password has already been entered or not.</div>
+
+<div>&nbsp;</div>
+
+<div class="important"><strong>Important:</strong>&nbsp;The password is stored in hashed form in the data base.</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Required parameters:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optional&nbsp;parameters:</li>
+	<li>
+	<ul>
+		<li class="parameter optional"><strong>minimumLength=Number</strong> - the minimum number of characters for the field (default 6).</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+  ])
+  ->setWhereEquals([
+      'constname' => 'CMSFIELD_CRYPTPASSWORD',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'de')
+  ->setFields([
+      '049_trans' => 'Passwort (sicher)',
+      'help_text' => '<div class="field-name"><strong>Feldname:</strong> beliebig</div>
+
+<div class="php-class"><strong>PHP Klasse:</strong> TCMSFieldPasswordEncrypted extends TCMSFieldPassword</div>
+
+<div>Erzeugt zwei Textfelder für Passwort und Passwort-Wiederholung. Außerdem wird ein Indikator für die Passwort-Qualität dargestellt.</div>
+
+<div>Das Feld zeigt zusätzlich an, ob bereits ein Passwort hinterlegt ist oder nicht.</div>
+
+<div>&nbsp;</div>
+
+<div class="important"><strong>Wichtig:</strong> Das Passwort wird gehasht/gesichert in der Datenbank gespeichert.</div>
+
+<div>&nbsp;</div>
+
+<div>
+<ul>
+	<li class="parameter required head">Pflicht-Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter required">n/a</li>
+	</ul>
+	</li>
+	<li>&nbsp;</li>
+	<li class="parameter optional head">Optionale Parameter:</li>
+	<li>
+	<ul>
+		<li class="parameter optional"><strong>minimumLength=Zahl</strong> - die minimale Zeichenzahl für das Feld (Standard 6).</li>
+	</ul>
+	</li>
+	<li>
+	<ul>
+	</ul>
+	</li>
+</ul>
+</div>
+',
+  ])
+  ->setWhereEquals([
+      'constname' => 'CMSFIELD_CRYPTPASSWORD',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+    ->setFields([
+        'fieldtype_config' => 'minimumLength=10',
+    ])
+    ->setWhereEquals([
+        'id' => TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('cms_user'), 'crypted_pw'),
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+TCMSLogChange::addInfoMessage('Minimum password length may now be configured in the fields "Password (secure)" and "Password (cleartext)".', TCMSLogChange::INFO_MESSAGE_LEVEL_INFO);

--- a/src/CoreBundle/Security/Password/PasswordHashGenerator.php
+++ b/src/CoreBundle/Security/Password/PasswordHashGenerator.php
@@ -39,6 +39,10 @@ class PasswordHashGenerator implements PasswordHashGeneratorInterface
      */
     public function verify($plainPassword, $hash)
     {
+        if (\mb_strlen($plainPassword) > self::MAXIMUM_PASSWORD_LENGTH) {
+            return false;
+        }
+
         return $this->hashAlgorithm->verify($plainPassword, $hash);
     }
 

--- a/src/CoreBundle/Security/Password/PasswordHashGeneratorInterface.php
+++ b/src/CoreBundle/Security/Password/PasswordHashGeneratorInterface.php
@@ -18,6 +18,8 @@ namespace ChameleonSystem\CoreBundle\Security\Password;
  */
 interface PasswordHashGeneratorInterface
 {
+    public const MAXIMUM_PASSWORD_LENGTH = 1000;
+
     /**
      * Returns a hashed password.
      *

--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -1147,13 +1147,11 @@ class TCMSLogChange
         );
         if (count($result) > 0) {
             $row = $result[0];
-            if (TCMSMessageManager::AUTO_CREATED_MARKER === substr($row['description'], 0, strlen(TCMSMessageManager::AUTO_CREATED_MARKER))) { // message stub found so update
-                $data->setFields($fields);
-                $data->setWhereEquals(array(
-                    'id' => $row['id'],
-                ));
-                self::update(__LINE__, $data);
-            }
+            $data->setFields($fields);
+            $data->setWhereEquals(array(
+                'id' => $row['id'],
+            ));
+            self::update(__LINE__, $data);
         } else { // not found... insert it
             $fields['name'] = $identifierName;
             $fields['id'] = self::createUnusedRecordId('cms_message_manager_backend_message');

--- a/src/ExtranetBundle/Bridge/Chameleon/Migration/Script/update-1536589748.inc.php
+++ b/src/ExtranetBundle/Bridge/Chameleon/Migration/Script/update-1536589748.inc.php
@@ -1,0 +1,41 @@
+<h1>Build #1536589748</h1>
+<h2>Date: 2018-09-10</h2>
+<div class="changelog">
+    - Configure minimum password length.
+</div>
+<?php
+
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+  ->setFields([
+      'fieldtype_config' => 'minimumLength=6',
+  ])
+  ->setWhereEquals([
+      'id' => TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('data_extranet_user'), 'password'),
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_message_manager_message', 'en')
+  ->setFields([
+      'description' => 'Password too long.',
+      'message' => 'Your password is too long. Please choose a shorter one.',
+  ])
+  ->setWhereEquals([
+      'name' => 'ERROR-USER-REGISTER-PWD-TO-LONG',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_message_manager_message', 'de')
+  ->setFields([
+      'description' => 'Passwort ist zu lang.',
+      'message' => 'Ihr Passwort ist zu lang. Bitte wählen Sie ein kürzeres Passwort.',
+  ])
+  ->setWhereEquals([
+      'name' => 'ERROR-USER-REGISTER-PWD-TO-LONG',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+TCMSLogChange::addInfoMessage('Minimum password length for extranet users is set to 6 characters which was the fixed value before this release. Consider increasing the value to at least 8 (see field config of the extranet user password field). This might require updating user information for the password policy.', TCMSLogChange::INFO_MESSAGE_LEVEL_INFO);

--- a/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
+++ b/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use ChameleonSystem\CoreBundle\DatabaseAccessLayer\DatabaseAccessLayerFieldConfig;
 use ChameleonSystem\CoreBundle\Interfaces\FlashMessageServiceInterface;
 use ChameleonSystem\CoreBundle\Security\Password\PasswordHashGeneratorInterface;
 use ChameleonSystem\CoreBundle\Service\ActivePageServiceInterface;
 use ChameleonSystem\CoreBundle\Service\PortalDomainServiceInterface;
+use ChameleonSystem\CoreBundle\ServiceLocator;
 use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
 use ChameleonSystem\CoreBundle\Util\UrlUtil;
 use ChameleonSystem\ExtranetBundle\Exception\PasswordGenerationFailedException;
@@ -286,7 +288,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
     public static function GetInstance($bReset = false)
     {
         /** @var $extranetUserProvider ExtranetUserProviderInterface */
-        $extranetUserProvider = \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_extranet.extranet_user_provider');
+        $extranetUserProvider = ServiceLocator::get('chameleon_system_extranet.extranet_user_provider');
         if ($bReset) {
             $extranetUserProvider->reset();
         }
@@ -559,7 +561,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     protected function getEventDispatcher()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('event_dispatcher');
+        return ServiceLocator::get('event_dispatcher');
     }
 
     /**
@@ -1874,8 +1876,8 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
             }
         }
 
-        $pwd1 = (isset($aData['password'])) ? ($aData['password']) : ('');
-        $pwd2 = (isset($aData['password2'])) ? ($aData['password2']) : ('');
+        $pwd1 = $aData['password'] ?? '';
+        $pwd2 = $aData['password2'] ?? '';
 
         // check pwd field
         if (empty($pwd1)) {
@@ -1905,7 +1907,6 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     public function ValidatePassword($sPassword, $sPasswordCopy)
     {
-        // check pwd field
         if (empty($sPassword)) {
             return 'ERROR-USER-REGISTER-PWD-REQUIRED';
         }
@@ -1914,11 +1915,32 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
             return 'ERROR-USER-REGISTER-PWD-NO-MATCH';
         }
 
-        if (mb_strlen($sPassword) < 6) {
+        $passwordLength = \mb_strlen($sPassword);
+        if ($passwordLength < $this->getMinimumPasswordLength()) {
             return 'ERROR-USER-REGISTER-PWD-TO-SHORT';
         }
 
+        if ($passwordLength > $this->getMaximumPasswordLength()) {
+            return 'ERROR-USER-REGISTER-PWD-TO-LONG';
+        }
+
         return true;
+    }
+
+    private function getMinimumPasswordLength(): int
+    {
+        $definition = $this->getDatabaseAccessLayerFieldConfig()->GetFieldDefinition('data_extranet_user', 'password');
+        $minimumLength = $definition->GetFieldtypeConfigKey('minimumLength');
+        if (false === \is_numeric($minimumLength)) {
+            return TCMSFieldPassword::DEFAULT_MINIMUM_PASSWORD_LENGTH;
+        }
+
+        return (int) $minimumLength;
+    }
+
+    private function getMaximumPasswordLength(): int
+    {
+        return PasswordHashGeneratorInterface::MAXIMUM_PASSWORD_LENGTH;
     }
 
     /**
@@ -2444,7 +2466,12 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getCurrentRequest()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('request_stack')->getCurrentRequest();
+        return ServiceLocator::get('request_stack')->getCurrentRequest();
+    }
+
+    private function getDatabaseAccessLayerFieldConfig(): DatabaseAccessLayerFieldConfig
+    {
+        return ServiceLocator::get('chameleon_system_core.database_access_layer_field_config');
     }
 
     /**
@@ -2452,7 +2479,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getPasswordHashGenerator()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.security.password.password_hash_generator');
+        return ServiceLocator::get('chameleon_system_core.security.password.password_hash_generator');
     }
 
     /**
@@ -2460,7 +2487,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getPortalDomainService()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.portal_domain_service');
+        return ServiceLocator::get('chameleon_system_core.portal_domain_service');
     }
 
     /**
@@ -2468,7 +2495,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getInputFilterUtil()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.util.input_filter');
+        return ServiceLocator::get('chameleon_system_core.util.input_filter');
     }
 
     /**
@@ -2476,7 +2503,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getActivePageService()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.active_page_service');
+        return ServiceLocator::get('chameleon_system_core.active_page_service');
     }
 
     /**
@@ -2484,7 +2511,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getFlashMessageService()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.flash_messages');
+        return ServiceLocator::get('chameleon_system_core.flash_messages');
     }
 
     /**
@@ -2492,7 +2519,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private static function getExtranetUserProvider()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_extranet.extranet_user_provider');
+        return ServiceLocator::get('chameleon_system_extranet.extranet_user_provider');
     }
 
     /**
@@ -2500,7 +2527,7 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getShopService()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_shop.shop_service');
+        return ServiceLocator::get('chameleon_system_shop.shop_service');
     }
 
     /**
@@ -2508,6 +2535,6 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      */
     private function getUrlUtil()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.util.url');
+        return ServiceLocator::get('chameleon_system_core.util.url');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#67
| License       | MIT

To add backend messages, I needed to adjust TCMSLogChange::AddBackEndMessage() slightly (can now modify all messages, not only default ones).