### PR TITLE
ref #82: Use portal infix also for resource collection files

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSResourceCollection.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSResourceCollection.class.php
@@ -151,10 +151,7 @@ class TCMSResourceCollection
     {
         $filesPrefix = ServiceLocator::getParameter('chameleon_system_core.resources.enable_external_resource_collection_refresh_prefix');
 
-        /**
-         * @var $portalDomainService PortalDomainServiceInterface
-         */
-        $portalDomainService = ServiceLocator::get('chameleon_system_core.portal_domain_service');
+        $portalDomainService = $this->getPortalDomainService();
         $portal = $portalDomainService->getActivePortal();
 
         if (null !== $portal) {
@@ -728,5 +725,10 @@ class TCMSResourceCollection
     private function getFileManager()
     {
         return ServiceLocator::get('chameleon_system_cms_file_manager.file_manager');
+    }
+
+    private function getPortalDomainService(): PortalDomainServiceInterface
+    {
+        return ServiceLocator::get('chameleon_system_core.portal_domain_service');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        |  6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#82
| License       | MIT

The portal (id) is now considered in resource collection file names: Content can be different and there can be links with domain name inside.