### PR TITLE
ref #80: Adjust permissions to delete images in frontend

### DIFF
--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordWritable.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordWritable.class.php
@@ -609,7 +609,7 @@ class TCMSRecordWritable extends TCMSRecord
     }
 
     /**
-     * deletes one or all images of an image field (all if iPos == null.
+     * deletes one or all images of an image field (all if iPos == null).
      *
      * @param string $sFieldName
      * @param int    $iPos
@@ -663,7 +663,9 @@ class TCMSRecordWritable extends TCMSRecord
 
             $tableEditor = new TCMSTableEditorManager();
             $tableEditor->Init($mediaTableConf->id, $imageId);
+            $tableEditor->AllowDeleteByAll(true);
             $tableEditor->Delete($imageId);
+            $tableEditor->AllowDeleteByAll(false);
 
             if (array_key_exists($imagePosition, $defaultImageIds)) {
                 $images[$imagePosition] = $defaultImageIds[$imagePosition];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#80
| License       | MIT

Circumvents permission checks for deleting images. I think this is OK because permissions for the operation are checked near the begin of the method (we could challenge in general that images can be completely deleted at this spot, but this fix doesn't change anything about that conceptual question). 