### PR TITLE
ref #111: Reset modules in case this is some kind of nested request (…

### DIFF
--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -162,6 +162,8 @@
         </service>
         <service id="chameleon_system_core.usermoduleloader" class="TUserModuleLoader" parent="chameleon_system_core.moduleloader" public="true" />
 
+        <service id="chameleon_system_core.subusermoduleloader" parent="chameleon_system_core.usermoduleloader" shared="false" public="true" />
+
         <service id="chameleon_system_core.base_controller" abstract="true">
             <argument type="service" id="request_stack"/>
             <argument type="service" id="event_dispatcher" />

--- a/src/CoreBundle/private/core/TModuleLoader.class.php
+++ b/src/CoreBundle/private/core/TModuleLoader.class.php
@@ -130,6 +130,7 @@ class TModuleLoader
      */
     public function LoadModules($moduleList, $templateLanguage = null)
     {
+        $this->modules = [];
         foreach ($moduleList as $name => $config) {
             // @TODO: check if the class is a descendant of TModelBase
             $this->modules[$name] = &$this->_SetModuleConfigData($name, $config, $templateLanguage);

--- a/src/CoreBundle/private/library/classes/TTools/TTools.class.php
+++ b/src/CoreBundle/private/library/classes/TTools/TTools.class.php
@@ -234,7 +234,7 @@ class TTools
     }
 
     /**
-     * fetches Module Loader Object.
+     * Fetches a new module loader instance..
      *
      * @param string $sModule     - class name of the module
      * @param string $sView       - view to use
@@ -245,7 +245,7 @@ class TTools
      */
     public static function &GetModuleLoaderObject($sModule, $sView, $aParameters = array(), $sSpotName = 'tmpmodule')
     {
-        $oModuleLoader = ServiceLocator::get('chameleon_system_core.usermoduleloader');
+        $oModuleLoader = self::getSubModuleLoader();
         $aModuleParameters = array('model' => $sModule, 'view' => $sView);
         $aModuleParameters = array_merge($aModuleParameters, $aParameters);
         $moduleList = array($sSpotName => $aModuleParameters);
@@ -2205,5 +2205,10 @@ class TTools
     private static function getServiceContainer()
     {
         return ServiceLocator::get('service_container');
+    }
+
+    private static function getSubModuleLoader(): TUserModuleLoader
+    {
+        return ServiceLocator::get('chameleon_system_core.subusermoduleloader');
     }
 }


### PR DESCRIPTION
…e.g. error page as called by ChameleonSystem\CoreBundle\Controller\ExceptionController)

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed issues  | chameleon-system/chameleon-system#111
| License       | MIT

The fix was surprisingly simple, so I suspect I might have missed something. The LoadModules() method is the first one called by ChameleonController and the one in which modules are added, so I think it fits "naturally" without having to care about the context in which the method is called.