### PR TITLE
ref #110: Use constant from Response for HTTP status

### DIFF
--- a/src/CoreBundle/i18n/Controller/JsTranslationController.php
+++ b/src/CoreBundle/i18n/Controller/JsTranslationController.php
@@ -60,6 +60,6 @@ CHAMELEON.CORE.i18n.isInitialized = true;
 CHAMELEON.CORE.i18n.Translation = {$exportString};
 JS;
 
-        return new Response($jsResponse, 200, ['Content-Type' => 'application/javascript']);
+        return new Response($jsResponse, Response::HTTP_OK, ['Content-Type' => 'application/javascript']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#110
| License       | MIT
