### PR TITLE
ref #147: acquire a lock only if the job needs execution. Abort only …

### DIFF
--- a/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
@@ -67,8 +67,12 @@ class TCMSCronJob extends TCMSRecord
      */
     public function RunScript($bForceExecution = false)
     {
-        if ((false === $bForceExecution && false === $this->_NeedExecution()) && false === $this->_Lock()) {
+        if (false === $bForceExecution && false === $this->_NeedExecution()) {
             return;
+        }
+
+        if (false === $this->_Lock()) {
+            return ;
         }
 
         $this->getLogger()->info(

--- a/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
@@ -72,7 +72,7 @@ class TCMSCronJob extends TCMSRecord
         }
 
         if (false === $this->_Lock()) {
-            return ;
+            return;
         }
 
         $this->getLogger()->info(


### PR DESCRIPTION
…if lock can not be acquired.

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#147
| License       | MIT
