### PR TITLE
ref #148: Add config for error reporting in cronjobs

### DIFF
--- a/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
+++ b/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
@@ -108,6 +108,17 @@ class ChameleonSystemCoreExtension extends Extension
     {
         $backendAccessCheckDefinition = $container->getDefinition('chameleon_system_core.security.backend_access_check');
         $backendAccessCheckDefinition->addMethodCall('unrestrictPagedef', array('runcrons', $cronjobConfig['ip_whitelist']));
+
+        $exceptionErrorLevel = $cronjobConfig['exception_error_level'];
+        if (-1 === $exceptionErrorLevel) {
+            $env = $container->getParameter('kernel.environment');
+            if ('prod' === $env) {
+                $exceptionErrorLevel = E_ALL & !E_NOTICE & !E_USER_NOTICE & !E_DEPRECATED & !E_USER_DEPRECATED;
+            } else {
+                $exceptionErrorLevel = E_ALL;
+            }
+        }
+        $container->setParameter('chameleon_system_core.cronjobs.exception_error_level', $exceptionErrorLevel);
     }
 
     /**

--- a/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
+++ b/src/CoreBundle/DependencyInjection/ChameleonSystemCoreExtension.php
@@ -109,16 +109,16 @@ class ChameleonSystemCoreExtension extends Extension
         $backendAccessCheckDefinition = $container->getDefinition('chameleon_system_core.security.backend_access_check');
         $backendAccessCheckDefinition->addMethodCall('unrestrictPagedef', array('runcrons', $cronjobConfig['ip_whitelist']));
 
-        $exceptionErrorLevel = $cronjobConfig['exception_error_level'];
-        if (-1 === $exceptionErrorLevel) {
-            $env = $container->getParameter('kernel.environment');
-            if ('prod' === $env) {
-                $exceptionErrorLevel = E_ALL & !E_NOTICE & !E_USER_NOTICE & !E_DEPRECATED & !E_USER_DEPRECATED;
+        $failOnErrorLevel = $cronjobConfig['fail_on_error_level'];
+        if (-1 === $failOnErrorLevel) {
+            $debug = $container->getParameter('kernel.debug');
+            if (true === $debug) {
+                $failOnErrorLevel = E_ALL;
             } else {
-                $exceptionErrorLevel = E_ALL;
+                $failOnErrorLevel = E_ALL & !E_NOTICE & !E_USER_NOTICE & !E_DEPRECATED & !E_USER_DEPRECATED;
             }
         }
-        $container->setParameter('chameleon_system_core.cronjobs.exception_error_level', $exceptionErrorLevel);
+        $container->setParameter('chameleon_system_core.cronjobs.fail_on_error_level', $failOnErrorLevel);
     }
 
     /**

--- a/src/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreBundle/DependencyInjection/Configuration.php
@@ -63,6 +63,14 @@ class Configuration implements ConfigurationInterface
                 ->defaultValue(array())
                 ->prototype('scalar')->end()
             ->end()
+            ->integerNode('exception_error_level')
+                ->defaultValue(-1)
+                ->info('A PHP error during a cronjob will terminate this cronjob if the error level is covered by
+                    this setting. If set to -1, notices and deprecation warnings will be ignored in the prod environment
+                    while in other environments all errors lead to termination of the job. This setting is intended for
+                    existing older cronjob implementations; new code should throw exceptions directly and not use PHP
+                    errors.')
+            ->end()
         ->end();
 
         return $subTree;

--- a/src/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreBundle/DependencyInjection/Configuration.php
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                 ->defaultValue(array())
                 ->prototype('scalar')->end()
             ->end()
-            ->integerNode('exception_error_level')
+            ->integerNode('fail_on_error_level')
                 ->defaultValue(-1)
                 ->info('A PHP error during a cronjob will terminate this cronjob if the error level is covered by
                     this setting (standard PHP error levels given as a bit mask, e.g. E_ALL & !E_NOTICE). If set to -1,

--- a/src/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreBundle/DependencyInjection/Configuration.php
@@ -66,10 +66,10 @@ class Configuration implements ConfigurationInterface
             ->integerNode('exception_error_level')
                 ->defaultValue(-1)
                 ->info('A PHP error during a cronjob will terminate this cronjob if the error level is covered by
-                    this setting. If set to -1, notices and deprecation warnings will be ignored in the prod environment
-                    while in other environments all errors lead to termination of the job. This setting is intended for
-                    existing older cronjob implementations; new code should throw exceptions directly and not use PHP
-                    errors.')
+                    this setting (standard PHP error levels given as a bit mask, e.g. E_ALL & !E_NOTICE). If set to -1,
+                    notices and deprecation warnings will be ignored in the prod environment while in other environments
+                    all errors lead to termination of the job. This setting is intended for existing older cronjob
+                    implementations; new code should throw exceptions directly and not use PHP errors.')
             ->end()
         ->end();
 

--- a/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
@@ -249,11 +249,11 @@ class TCMSCronJob extends TCMSRecord
      **/
     private function setExceptionErrorHandler()
     {
-        $exceptionErrorLevel = $this->getExceptionErrorLevel();
+        $failureErrorLevel = $this->getFailureErrorLevel();
 
         return set_error_handler(
-            function ($severity, $message, $file, $line) use ($exceptionErrorLevel) {
-                if (0 === ($exceptionErrorLevel & $severity)) {
+            function ($severity, $message, $file, $line) use ($failureErrorLevel) {
+                if (0 === ($failureErrorLevel & $severity)) {
                     return;
                 }
                 throw new ErrorException($message, 0, $severity, $file, $line);
@@ -261,9 +261,9 @@ class TCMSCronJob extends TCMSRecord
         );
     }
 
-    private function getExceptionErrorLevel(): int
+    private function getFailureErrorLevel(): int
     {
-        return ServiceLocator::getParameter('chameleon_system_core.cronjobs.exception_error_level');
+        return ServiceLocator::getParameter('chameleon_system_core.cronjobs.fail_on_error_level');
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/CronJobs/TCMSCronJob.class.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+use ChameleonSystem\CoreBundle\ServiceLocator;
+
 /**
  * manages a cronjob.
 /**/
@@ -56,7 +58,7 @@ class TCMSCronJob extends TCMSRecord
      */
     protected function getLogger()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('cmsPkgCore.logChannel.cronjobs');
+        return ServiceLocator::get('cmsPkgCore.logChannel.cronjobs');
     }
 
     /**
@@ -247,15 +249,21 @@ class TCMSCronJob extends TCMSRecord
      **/
     private function setExceptionErrorHandler()
     {
+        $exceptionErrorLevel = $this->getExceptionErrorLevel();
+
         return set_error_handler(
-            function ($severity, $message, $file, $line) {
-                if (!(error_reporting() & $severity)) {
-                    // This error code is not included in error_reporting - taken from the php documentation
+            function ($severity, $message, $file, $line) use ($exceptionErrorLevel) {
+                if (0 === ($exceptionErrorLevel & $severity)) {
                     return;
                 }
                 throw new ErrorException($message, 0, $severity, $file, $line);
             }
         );
+    }
+
+    private function getExceptionErrorLevel(): int
+    {
+        return ServiceLocator::getParameter('chameleon_system_core.cronjobs.exception_error_level');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#148
| License       | MIT

The error levels on which to fail can now be configured. Besides being configurable, the benefit of this approach is that environment-specific code is limited as far as possible.