### PR TITLE
173 validate before save field

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
@@ -846,12 +846,12 @@ class TCMSField implements TCMSFieldVisitableInterface
     /**
      * Renames existing related table.
      *
-     * @param string $sNewTableName
-     * @param bool   $returnDDL
+     * @param array $newFieldData
+     * @param bool  $returnDDL
      *
      * @return string|null
      */
-    public function RenameRelatedTables($sNewTableName, $returnDDL = false)
+    public function RenameRelatedTables($newFieldData, $returnDDL = false)
     {
         if ($returnDDL) {
             return '';

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -175,6 +175,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $newTypeId = $postData['cms_field_type_id'];
         $newName = $this->oTable->sqlData['name'];
 
+        // TODO!
         $this->oldField->oDefinition = $this->oldFieldDefinition; // something in parent::Save has changed $this->oldField->oDefinition
 
         $bTypeChanged = $oldTypeId !== $newTypeId;
@@ -189,11 +190,10 @@ class TCMSTableFieldWriter extends TCMSTableEditor
             if (true === $this->oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
                 $this->oldField->DeleteRelatedTables();
             } elseif (true === $this->oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
-                $this->oldField->RenameRelatedTables($newName);
-                // TODO $newName is wrong here! Must be array
+                $this->oldField->RenameRelatedTables($postData);
             }
         } else {
-            $this->oldField->RenameRelatedTables($newName);
+            $this->oldField->RenameRelatedTables($postData);
         }
         $this->oldField->RemoveFieldIndex();
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -184,14 +184,14 @@ class TCMSTableFieldWriter extends TCMSTableEditor
             $oldField->ChangeFieldTypePreHook();
         }
 
-        if (false === $this->prohibitChangesOnRelatedTables) {
+        if (true === $this->prohibitChangesOnRelatedTables) {
+            $oldField->RenameRelatedTables($postData);
+        } else {
             if (true === $oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
                 $oldField->DeleteRelatedTables();
             } elseif (true === $oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
                 $oldField->RenameRelatedTables($postData);
             }
-        } else {
-            $oldField->RenameRelatedTables($postData);
         }
         $oldField->RemoveFieldIndex();
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -169,7 +169,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $newName = $this->oTable->sqlData['name'];
 
         $isTypeChange = $oldTypeId !== $newTypeId;
-        $currentFieldTypeRow = $this->getFieldTypeDefinition($oldTypeId);
+        $oldFieldTypeRow = $this->getFieldTypeDefinition($oldTypeId);
         $newFieldTypeRow = $this->getFieldTypeDefinition($newTypeId);
 
         /**
@@ -185,9 +185,9 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         }
 
         if (false === $this->isChangeFromTable) {
-            if (true === $oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
+            if (true === $oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
                 $oldField->DeleteRelatedTables();
-            } elseif (true === $oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
+            } elseif (true === $oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
                 $oldField->RenameRelatedTables($postData);
             }
         } else {
@@ -224,7 +224,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
 
         // NOTE Save() was called here before the code was reorganized - hence the method names
 
-        if (false === $this->isChangeFromTable && true === $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $currentFieldTypeRow, $newFieldTypeRow)) {
+        if (false === $this->isChangeFromTable && true === $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $oldFieldTypeRow, $newFieldTypeRow)) {
             $newField->CreateRelatedTables();
         }
         $newField->CreateFieldIndex();

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -46,7 +46,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
     /**
      * @var bool
      */
-    private $isChangeFromTable = false;
+    private $prohibitChangesOnRelatedTables = false;
 
     /**
      * @return TCMSStdClass
@@ -138,7 +138,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
 
         $this->oldData = $this->oTable->sqlData;
         $this->oldTableName = $this->_oParentRecord->sqlData['name'];
-        $this->isChangeFromTable = $postData['bTargetTableChangeForMLTField'] ?? false; // true (from TCMSTableWriter) prohibits target changes
+        $this->prohibitChangesOnRelatedTables = $postData['bTargetTableChangeForMLTField'] ?? false; // true (from TCMSTableWriter) prohibits target changes
 
         return parent::Save($postData);
     }
@@ -184,7 +184,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
             $oldField->ChangeFieldTypePreHook();
         }
 
-        if (false === $this->isChangeFromTable) {
+        if (false === $this->prohibitChangesOnRelatedTables) {
             if (true === $oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
                 $oldField->DeleteRelatedTables();
             } elseif (true === $oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $oldFieldTypeRow, $newFieldTypeRow)) {
@@ -224,7 +224,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
 
         // NOTE Save() was called here before the code was reorganized - hence the method names
 
-        if (false === $this->isChangeFromTable && true === $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $oldFieldTypeRow, $newFieldTypeRow)) {
+        if (false === $this->prohibitChangesOnRelatedTables && true === $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $oldFieldTypeRow, $newFieldTypeRow)) {
             $newField->CreateRelatedTables();
         }
         $newField->CreateFieldIndex();

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -181,14 +181,14 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $currentFieldTypeRow = $this->getFieldTypeDefinition($oldTypeId);
         $newFieldTypeRow = $this->getFieldTypeDefinition($newTypeId);
 
-        if ($bTypeChanged) {
+        if (true === $bTypeChanged) {
             $this->oldField->ChangeFieldTypePreHook();
         }
 
         if (false === $this->isChangeFromTable) {
-            if ($this->oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
+            if (true === $this->oldField->AllowDeleteRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
                 $this->oldField->DeleteRelatedTables();
-            } elseif ($this->_oField->AllowRenameRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
+            } elseif (true === $this->oldField->AllowRenameRelatedTablesBeforeFieldSave($postData, $currentFieldTypeRow, $newFieldTypeRow)) {
                 $this->oldField->RenameRelatedTables($newName);
                 // TODO $newName is wrong here! Must be array
             }
@@ -208,14 +208,14 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $newField->sTableName = $this->_oParentRecord->sqlData['name'];
         $newField->recordId = $this->sId;
         $newField->oDefinition = &$this->oTable;
-        if ($bTypeChanged) {
+        if (true === $bTypeChanged) {
             $newField->ChangeFieldTypePostHook();
         }
         $newField->ChangeFieldDefinition($this->oldData['name'], $newName, $postData);
 
         // NOTE here was Save() before the reorganization - hence the method names
 
-        if (false === $this->isChangeFromTable && $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $currentFieldTypeRow, $newFieldTypeRow)) {
+        if (false === $this->isChangeFromTable && true === $newField->AllowCreateRelatedTablesAfterFieldSave($this->oldData, $currentFieldTypeRow, $newFieldTypeRow)) {
             $newField->CreateRelatedTables();
         }
         $newField->CreateFieldIndex();

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -168,7 +168,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $newTypeId = $postData['cms_field_type_id'];
         $newName = $this->oTable->sqlData['name'];
 
-        $bTypeChanged = $oldTypeId !== $newTypeId;
+        $isTypeChange = $oldTypeId !== $newTypeId;
         $currentFieldTypeRow = $this->getFieldTypeDefinition($oldTypeId);
         $newFieldTypeRow = $this->getFieldTypeDefinition($newTypeId);
 
@@ -180,7 +180,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $oldField->sTableName = $this->oldTableName;
         $oldField->name = $this->oldData['name'];
 
-        if (true === $bTypeChanged) {
+        if (true === $isTypeChange) {
             $oldField->ChangeFieldTypePreHook();
         }
 
@@ -205,7 +205,7 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         $newField->sTableName = $this->_oParentRecord->sqlData['name'];
         $newField->recordId = $this->sId;
         $newField->oDefinition = &$this->oTable;
-        if (true === $bTypeChanged) {
+        if (true === $isTypeChange) {
             $newField->ChangeFieldTypePostHook();
         }
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -199,12 +199,12 @@ class TCMSTableFieldWriter extends TCMSTableEditor
         /**
          * @var $newField TCMSField
          */
-        $newField = &$this->oTable->GetFieldObject();
+        $newField = $this->oTable->GetFieldObject();
 
         $newField->name = $newName;
         $newField->sTableName = $this->_oParentRecord->sqlData['name'];
         $newField->recordId = $this->sId;
-        $newField->oDefinition = &$this->oTable;
+        $newField->oDefinition = $this->oTable;
         if (true === $isTypeChange) {
             $newField->ChangeFieldTypePostHook();
         }

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -237,17 +237,23 @@ class TCMSTableFieldWriter extends TCMSTableEditor
     /**
      * @param string $typeId
      *
-     * @return array|bool
+     * @return array|null
      *
      * @throws DBALException
      */
-    private function getFieldTypeDefinition(string $typeId)
+    private function getFieldTypeDefinition(string $typeId): ?array
     {
         $databaseConnection = $this->getDatabaseConnection();
 
         $query = 'SELECT * FROM `cms_field_type` WHERE `id` = :typeId';
 
-        return $databaseConnection->fetchAssoc($query, ['typeId' => $typeId]);
+        $fieldTypeData = $databaseConnection->fetchAssoc($query, ['typeId' => $typeId]);
+
+        if (false === $fieldTypeData) {
+            return null;
+        }
+
+        return $fieldTypeData;
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableFieldWriter.class.php
@@ -157,7 +157,9 @@ class TCMSTableFieldWriter extends TCMSTableEditor
 
     /**
      * @param array $postData
+     *
      * @return TCMSField - the new definition after changes
+     *
      * @throws DBALException
      */
     protected function adaptFieldAndRelatedTables(array $postData): TCMSField
@@ -192,7 +194,6 @@ class TCMSTableFieldWriter extends TCMSTableEditor
             $oldField->RenameRelatedTables($postData);
         }
         $oldField->RemoveFieldIndex();
-
 
         $this->oTable->sqlData['cms_field_type_id'] = $newTypeId;
         /**
@@ -235,7 +236,9 @@ class TCMSTableFieldWriter extends TCMSTableEditor
 
     /**
      * @param string $typeId
+     *
      * @return array|bool
+     *
      * @throws DBALException
      */
     private function getFieldTypeDefinition(string $typeId)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#173
| License       | MIT

Uses now validation before save: most functionality is moved to "PostSaveHook()".
Table fields are correctly created and deleted if needed.