### PR TITLE
WIP ref #97: Provide session as non-synthetic service

### DIFF
--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -113,9 +113,6 @@
 
         <service id="chameleon_system_core.service_initializer.request" class="ChameleonSystem\CoreBundle\Service\Initializer\RequestInitializer">
             <argument type="service" id="chameleon_system_core.response.response_variable_replacer" />
-            <call method="setSessionManager">
-                <argument type="service" id="chameleon_system_core.session.chameleon_session_manager" />
-            </call>
         </service>
 
         <service id="chameleon_system_core.InitializeRequestListener" class="ChameleonSystem\CoreBundle\EventListener\InitializeRequestListener" public="true">
@@ -124,20 +121,19 @@
         </service>
 
         <service id="chameleon_system_core.session.chameleon_session_manager" class="ChameleonSystem\CoreBundle\Session\ChameleonSessionManager" public="true">
-            <argument type="service" id="request_stack" />
             <argument type="service" id="database_connection" />
             <argument type="service" id="chameleon_system_core.sessionPdo" />
-            <argument type="service" id="service_container" />
             <argument>%session.metadata.update_threshold%</argument>
             <argument>%session.storage.options%</argument>
-            <argument type="service" id="chameleon_system_core.util.input_filter" />
         </service>
 
         <service id="chameleon_system_core.ChameleonSessionManager" alias="chameleon_system_core.session.chameleon_session_manager" public="true">
             <deprecated>The "%service_id%" service is deprecated since Chameleon 6.2.0 - use chameleon_system_core.session.chameleon_session_manager instead.</deprecated>
         </service>
 
-        <service id="session" synthetic="true" public="true"/>
+        <service id="session" class="TPkgCmsSession" public="true">
+            <factory service="chameleon_system_core.session.chameleon_session_manager" method="boot" />
+        </service>
 
         <service id="chameleon_system_core.chameleon_controller" synthetic="true" public="true"/>
 

--- a/src/CoreBundle/Service/Initializer/RequestInitializer.php
+++ b/src/CoreBundle/Service/Initializer/RequestInitializer.php
@@ -12,19 +12,11 @@
 namespace ChameleonSystem\CoreBundle\Service\Initializer;
 
 use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
-use ChameleonSystem\CoreBundle\Session\ChameleonSessionManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use TGlobal;
 
-/**
- * Class RequestInitializer.
- */
 class RequestInitializer
 {
-    /**
-     * @var ChameleonSessionManagerInterface
-     */
-    private $sessionManager;
     /**
      * @var ResponseVariableReplacerInterface
      */
@@ -35,9 +27,6 @@ class RequestInitializer
         $this->responseVariableReplacer = $responseVariableReplacer;
     }
 
-    /**
-     * @param Request $request
-     */
     public function initialize(Request $request)
     {
         // removed check for request type here. If we need it for something else here besides the setting via chameleon::boot, look here again
@@ -46,7 +35,6 @@ class RequestInitializer
 
         $this->addStaticURLs();
         $this->addSchemeVariable($request);
-        $this->sessionManager->boot();
         $this->transformParameters($request);
     }
 
@@ -69,14 +57,6 @@ class RequestInitializer
         if (!_DEVELOPMENT_MODE && USE_DEFAULT_ERROR_HANDLER) {
             register_shutdown_function(array('TCMSErrorHandler', 'ShutdownHandler'));
         }
-    }
-
-    /**
-     * @param ChameleonSessionManagerInterface $sessionManager
-     */
-    public function setSessionManager($sessionManager)
-    {
-        $this->sessionManager = $sessionManager;
     }
 
     protected function addStaticURLs()

--- a/src/ExtranetBundle/EventListener/ValidateLoginDataListener.php
+++ b/src/ExtranetBundle/EventListener/ValidateLoginDataListener.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\ExtranetBundle\EventListener;
+
+use ChameleonSystem\CoreBundle\Service\RequestInfoServiceInterface;
+use ChameleonSystem\ExtranetBundle\Interfaces\ExtranetUserProviderInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class ValidateLoginDataListener
+{
+    /**
+     * @var RequestInfoServiceInterface
+     */
+    private $requestInfoService;
+    /**
+     * @var ExtranetUserProviderInterface
+     */
+    private $extranetUserProvider;
+
+    public function __construct(RequestInfoServiceInterface $requestInfoService, ExtranetUserProviderInterface $extranetUserProvider)
+    {
+        $this->requestInfoService = $requestInfoService;
+        $this->extranetUserProvider = $extranetUserProvider;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event): void
+    {
+        if (false === $event->isMasterRequest()) {
+            return;
+        }
+        if (true === $this->requestInfoService->isBackendMode()) {
+            return;
+        }
+
+        $activeUser = $this->extranetUserProvider->getActiveUser();
+        if (null === $activeUser) {
+            return;
+        }
+        $activeUser->validateLogin();
+    }
+}

--- a/src/ExtranetBundle/Resources/config/services.xml
+++ b/src/ExtranetBundle/Resources/config/services.xml
@@ -24,6 +24,13 @@
             <tag name="kernel.event_listener" event="chameleon_system_extranet.user_login_success" method="refreshAuthenticityToken" />
         </service>
 
+        <service id="chamelon_system_extranet.event_listener.validate_login_data_listener" class="ChameleonSystem\ExtranetBundle\EventListener\ValidateLoginDataListener">
+            <argument type="service" id="chameleon_system_core.request_info_service"/>
+            <argument type="service" id="chameleon_system_extranet.extranet_user_provider"/>
+            <!-- We set the priority as high as possible but not before session_listener as we need the session from the request -->
+            <tag name="kernel.event_listener" event="kernel.request" priority="127" />
+        </service>
+
         <service id="chameleon_system_extranet.extranet_user_provider" class="ChameleonSystem\ExtranetBundle\Service\ExtranetUserProvider" public="true">
             <argument type="service" id="request_stack" />
         </service>

--- a/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
+++ b/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
@@ -2450,12 +2450,8 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function sessionWakeupHook()
+    public function validateLogin()
     {
-        parent::sessionWakeupHook();
         if (true === $this->ValidateSessionData()) {
             $this->isLoggedIn = true;
         } elseif (null !== $this->id && $this->ForceLogoutOnInstanceLoading()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (mosty in parts not covered by the BC promise)
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#97
| License       | MIT

This PR basically solves the problem of the non-injectable session service. ChameleonSessionManager serves as a factory, allowing the same custom session functionality as before.

While the change itself is relatively simple, its implications are not. The session is now constructed before the request is available, so we can't inject the session into the request during construction. Unfortunately we already need the request during session start for some objects that get deserialized from the session, like the extranet user or the shop basket. This PR therefore also moves some part of the user deserialisation to a kernel.request listener.

The problem is that we get deep into some rabbit hole: I managed to decouple part of the shop basket deserialization in a similar way (no PR yet), but when switching the language during checkout, there is still a crash. I fear there will be other crashes hidden anywhere in the system, so I'd question if it is currently worth the time to figure out everything.