### PR TITLE
ref #119: Do not redirect when maintenance mode late check is true

### DIFF
--- a/src/CoreBundle/EventListener/InitializeRequestListener.php
+++ b/src/CoreBundle/EventListener/InitializeRequestListener.php
@@ -64,10 +64,11 @@ class InitializeRequestListener
     private function recheckMaintenanceMode(GetResponseEvent $event): void
     {
         if (true === $this->maintenanceModeService->isActive()) {
-            $this->redirectToCurrentPage($event);
+            $this->showMaintenanceModePage();
         }
     }
 
+    // TODO not used: see #119 - this probably needs a different solution.
     private function redirectToCurrentPage(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
@@ -77,5 +78,16 @@ class InitializeRequestListener
             // Redirect is not meaningful for a POST request:
             $event->setResponse(new Response('Maintenance mode is active.', Response::HTTP_SERVICE_UNAVAILABLE));
         }
+    }
+
+    private function showMaintenanceModePage(): void
+    {
+        if (\file_exists(PATH_WEB.'/maintenance.php')) {
+            require PATH_WEB.'/maintenance.php';
+
+            exit();
+        }
+
+        die('Sorry! This page is down for maintenance.');
     }
 }

--- a/src/CoreBundle/EventListener/InitializeRequestListener.php
+++ b/src/CoreBundle/EventListener/InitializeRequestListener.php
@@ -55,28 +55,16 @@ class InitializeRequestListener
         }
 
         if (false === $this->requestInfoService->isBackendMode() && false === $this->requestInfoService->isCmsTemplateEngineEditMode()) {
-            $this->recheckMaintenanceMode($event);
+            $this->recheckMaintenanceMode();
         }
 
         $this->requestInitializer->initialize($event->getRequest());
     }
 
-    private function recheckMaintenanceMode(GetResponseEvent $event): void
+    private function recheckMaintenanceMode(): void
     {
         if (true === $this->maintenanceModeService->isActive()) {
             $this->showMaintenanceModePage();
-        }
-    }
-
-    // TODO not used: see #119 - this probably needs a different solution.
-    private function redirectToCurrentPage(GetResponseEvent $event): void
-    {
-        $request = $event->getRequest();
-        if (true === $request->isMethodSafe()) {
-            $event->setResponse(new RedirectResponse($_SERVER['REQUEST_URI']));
-        } else {
-            // Redirect is not meaningful for a POST request:
-            $event->setResponse(new Response('Maintenance mode is active.', Response::HTTP_SERVICE_UNAVAILABLE));
         }
     }
 

--- a/src/CoreBundle/EventListener/InitializeRequestListener.php
+++ b/src/CoreBundle/EventListener/InitializeRequestListener.php
@@ -14,8 +14,6 @@ namespace ChameleonSystem\CoreBundle\EventListener;
 use ChameleonSystem\CoreBundle\Maintenance\MaintenanceMode\MaintenanceModeServiceInterface;
 use ChameleonSystem\CoreBundle\Service\Initializer\RequestInitializer;
 use ChameleonSystem\CoreBundle\Service\RequestInfoServiceInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class InitializeRequestListener

--- a/src/CoreBundle/FrontController/chameleon.php
+++ b/src/CoreBundle/FrontController/chameleon.php
@@ -210,14 +210,15 @@ class chameleon
             || (isset($_POST['__modulechooser']) && 'true' === $_POST['__modulechooser']);
     }
 
-    private function showMaintenanceModePage()
+    private function showMaintenanceModePage(): void
     {
-        if (file_exists(PATH_WEB.'/maintenance.php')) {
+        if (\file_exists(PATH_WEB.'/maintenance.php')) {
             require PATH_WEB.'/maintenance.php';
+
             exit();
-        } else {
-            die('down for maintenance');
         }
+
+        die('Sorry! This page is down for maintenance.');
     }
 
     private function clearMaintenanceModeMarkerFileCache(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#119
| License       | MIT

Fixes the problem that on very slow shared file system between multiple nodes the maintenance mode marker file might really be missing for seconds.
During this time a redirect would not work and redirect again.