### PR TITLE
WIP Feature/94 symfony flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/polyfill-apcu": "^1.0",
         "symfony/console": "~3.4.0",
         "symfony/dependency-injection": "~3.4.0",
+        "symfony/expression-language": "~3.4.0",
         "symfony/framework-bundle": "~3.4.0",
         "symfony/routing": "~3.4.0",
         "symfony/security-csrf": "~3.4.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,13 @@
         "sensio/distribution-bundle": "^5.0.19",
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
-        "symfony/symfony": "~3.4.0",
+        "symfony/console": "~3.4.0",
+        "symfony/dependency-injection": "~3.4.0",
+        "symfony/framework-bundle": "~3.4.0",
+        "symfony/routing": "~3.4.0",
+        "symfony/templating": "~3.4.0",
+        "symfony/validator": "~3.4.0",
+        "symfony/yaml": "~3.4.0",
         "symfony-cmf/routing-bundle": "~2.1.0",
         "tedivm/jshrink": "~1.0",
         "twig/twig": "^2.0"
@@ -34,7 +40,10 @@
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "dev-master",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~7.0",
+        "symfony/debug-bundle": "~3.4.0",
+        "symfony/stopwatch": "~3.4.0",
+        "symfony/web-profiler-bundle": "~3.4.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "chameleon-system/sanitycheck-bundle": "dev-master",
         "ckeditor/ckeditor": "4.6.2",
         "doctrine/dbal": "~2.5",
+        "doctrine/doctrine-bundle": "^1.6.10",
         "ext-curl": "*",
         "ext-tidy": "*",
         "ext-pdo_mysql": "*",
@@ -23,10 +24,10 @@
         "natxet/CssMin": "~3.0.0",
         "php": "^7.1",
         "phpmailer/phpmailer": "~6.0",
+        "symfony/config": "~3.4.0",
         "symfony/console": "~3.4.0",
         "symfony/dependency-injection": "~3.4.0",
         "symfony/expression-language": "~3.4.0",
-        "symfony/flex": "^1.1.0",
         "symfony/framework-bundle": "~3.4.0",
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
@@ -44,8 +45,7 @@
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "dev-master",
-        "phpunit/phpunit": "~7.0",
-        "symfony/dotenv": "~3.4.0"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,17 @@
         "natxet/CssMin": "~3.0.0",
         "php": "^7.1",
         "phpmailer/phpmailer": "~6.0",
-        "sensio/distribution-bundle": "^5.0.19",
-        "symfony/monolog-bundle": "^3.1.0",
-        "symfony/polyfill-apcu": "^1.0",
         "symfony/console": "~3.4.0",
         "symfony/dependency-injection": "~3.4.0",
         "symfony/expression-language": "~3.4.0",
+        "symfony/flex": "^1.1.0",
         "symfony/framework-bundle": "~3.4.0",
+        "symfony/monolog-bundle": "^3.1.0",
+        "symfony/polyfill-apcu": "^1.0",
         "symfony/routing": "~3.4.0",
         "symfony/security-csrf": "~3.4.0",
         "symfony/templating": "~3.4.0",
+        "symfony/translation": "~3.4.0",
         "symfony/twig-bundle": "~3.4.0",
         "symfony/validator": "~3.4.0",
         "symfony/yaml": "~3.4.0",
@@ -43,7 +44,8 @@
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "dev-master",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~7.0",
+        "symfony/dotenv": "~3.4.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/dependency-injection": "~3.4.0",
         "symfony/framework-bundle": "~3.4.0",
         "symfony/routing": "~3.4.0",
+        "symfony/security-csrf": "~3.4.0",
         "symfony/templating": "~3.4.0",
         "symfony/twig-bundle": "~3.4.0",
         "symfony/validator": "~3.4.0",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/framework-bundle": "~3.4.0",
         "symfony/routing": "~3.4.0",
         "symfony/templating": "~3.4.0",
+        "symfony/twig-bundle": "~3.4.0",
         "symfony/validator": "~3.4.0",
         "symfony/yaml": "~3.4.0",
         "symfony-cmf/routing-bundle": "~2.1.0",
@@ -40,10 +41,7 @@
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "dev-master",
-        "phpunit/phpunit": "~7.0",
-        "symfony/debug-bundle": "~3.4.0",
-        "symfony/stopwatch": "~3.4.0",
-        "symfony/web-profiler-bundle": "~3.4.0"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "classmap": [

--- a/src/AutoclassesBundle/Resources/config/services.xml
+++ b/src/AutoclassesBundle/Resources/config/services.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="chameleon_system_autoclasses.cache_warmer.class">ChameleonSystem\AutoclassesBundle\CacheWarmer\AutoclassesCacheWarmer</parameter>
-        <parameter key="chameleon_system_autoclasses.cache_warmer.autoclasses_dir">%kernel.root_dir%/cache/autoclasses/</parameter>
+        <parameter key="chameleon_system_autoclasses.cache_warmer.autoclasses_dir">%kernel.project_dir%/var/cache/autoclasses/</parameter>
         <parameter key="chameleon_system_autoclasses.request_listener.class">ChameleonSystem\AutoclassesBundle\Listener\RequestListener</parameter>
     </parameters>
 

--- a/src/CmsCacheBundle/Resources/config/services.xml
+++ b/src/CmsCacheBundle/Resources/config/services.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="request_stack" />
             <argument type="service" id="chameleon_system_cms_cache.cache_database_connection" />
             <argument type="service" id="chameleon_system_cms_cache.storage.null" />
-            <argument>%secret%</argument>
+            <argument>%env(APP_SECRET)%</argument>
             <argument>%chameleon_system_core.cache.allow%</argument>
             <argument type="service" id="chameleon_system_core.util.hash_array"/>
             <argument type="service" id="chameleon_system_core.request_state_hash_provider"/>

--- a/src/CmsTextBlockBundle/Service/TextBlockLookup.php
+++ b/src/CmsTextBlockBundle/Service/TextBlockLookup.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ChameleonSystem\CmstextBlockBundle\Service;
+namespace ChameleonSystem\CmsTextBlockBundle\Service;
 
 use ChameleonSystem\CmsTextBlockBundle\Interfaces\TextBlockLookupInterface;
 use TdbPkgCmsTextBlock;

--- a/src/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreBundle/DependencyInjection/Configuration.php
@@ -95,7 +95,9 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('enabled')
                 ->defaultValue(false)
             ->end()
-            ->scalarNode('subject_prefix')->end()
+            ->scalarNode('subject_prefix')
+                ->defaultValue('')
+            ->end()
         ->end();
 
         return $subTree;

--- a/src/CoreBundle/FrontController/chameleon.php
+++ b/src/CoreBundle/FrontController/chameleon.php
@@ -51,7 +51,6 @@ class chameleon
             exit(0);
         }
         mb_internal_encoding('UTF-8');
-        $this->InitAutoloader();
         if ('console' === REQUEST_PROTOCOL) {
             $requestType = RequestTypeInterface::REQUEST_TYPE_BACKEND;
         } else {
@@ -89,11 +88,6 @@ class chameleon
         if ($this->isInMaintenanceMode($requestType)) {
             $this->showMaintenanceModePage();
         }
-    }
-
-    private function InitAutoloader()
-    {
-        require_once realpath(PATH_PROJECT_BASE.'/app/autoload.php');
     }
 
     /**

--- a/src/CoreBundle/FrontController/index.php
+++ b/src/CoreBundle/FrontController/index.php
@@ -9,7 +9,11 @@
  * file that was distributed with this source code.
  */
 
+use App\Kernel;
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
+
+require __DIR__.'/../../../../../../src/.bootstrap.php';
 
 require_once dirname(__DIR__).'/Resources/config/const.inc.php';
 
@@ -29,21 +33,20 @@ if ((array_key_exists('HTTPS', $_SERVER) && 'on' === $_SERVER['HTTPS'])
 
 require_once PATH_PROJECT_CONFIG.'/config.inc.php';
 
+define('_DEVELOPMENT_MODE', $_SERVER['APP_DEBUG']);
+
+if (true === $_SERVER['APP_DEBUG']) {
+    umask(0000);
+    Debug::enable();
+}
+
 require_once __DIR__.'/chameleon.php';
 $chameleon = new chameleon();
 $chameleon->boot();
 
 spl_autoload_register('ChameleonSystem\AutoclassesBundle\Loader\AutoClassLoader::loadClassDefinition');
 
-require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
-
-$devmode = defined('_DEVELOPMENT_MODE') && _DEVELOPMENT_MODE === true;
-$env = $devmode ? 'dev' : 'prod';
-//if($devmode) {
-//    Symfony\Component\Debug\Debug::enable(null, false);
-//}
-
-$kernel = new AppKernel($env, $devmode);
+$kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/src/CoreBundle/Resources/config/checks.xml
+++ b/src/CoreBundle/Resources/config/checks.xml
@@ -46,26 +46,26 @@
         <service id="chameleon_system_core.check_cms_dir_writable"  parent="chameleon_system_sanity_check.check.file_permission">
             <argument>%chameleon_system_sanity_check.level.error%</argument>
             <argument type="collection">
-                <argument>cmsdata</argument>
-                <argument>cache</argument>
-                <argument>cache/autoclasses</argument>
-                <argument>logs</argument>
-                <argument>../web/chameleon/mediapool</argument>
-                <argument>../web/chameleon/outbox/static/css</argument>
-                <argument>../web/chameleon/outbox/static/js</argument>
-                <argument>../web/chameleon/outbox/static/less</argument>
+                <argument>var/cmsdata</argument>
+                <argument>var/cache</argument>
+                <argument>var/cache/autoclasses</argument>
+                <argument>var/log</argument>
+                <argument>public/chameleon/mediapool</argument>
+                <argument>public/chameleon/outbox/static/css</argument>
+                <argument>public/chameleon/outbox/static/js</argument>
+                <argument>public/chameleon/outbox/static/less</argument>
             </argument>
             <argument type="collection">
                 <argument>READ</argument>
                 <argument>WRITE</argument>
             </argument>
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
             <tag name="chameleon_system.sanity_check.check" translation_key="label.directorieswritable" />
         </service>
 
         <service id="chameleon_system_core.check_disk_space"  parent="chameleon_system_sanity_check.check.disk_space">
             <argument>%chameleon_system_sanity_check.level.error%</argument>
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
             <argument type="collection">
                 <argument key="%chameleon_system_sanity_check.level.warning%">1GiB</argument>
                 <argument key="%chameleon_system_sanity_check.level.error%">100MiB</argument>

--- a/src/CoreBundle/Resources/config/const.inc.php
+++ b/src/CoreBundle/Resources/config/const.inc.php
@@ -4,7 +4,7 @@ if (!defined('PATH_WEB')) {
     define('PATH_WEB', $_SERVER['DOCUMENT_ROOT']);
 }
 define('PATH_PROJECT_BASE', PATH_WEB.'/../');
-define('PATH_PROJECT_CONFIG', PATH_PROJECT_BASE.'/app/config/');
+define('PATH_PROJECT_CONFIG', PATH_PROJECT_BASE.'/config/');
 /**
  * @deprecated since 6.2.0 - the vendor path should no longer be used. Use the bundle syntax to refer to concrete bundles instead.
  */

--- a/src/CoreBundle/Resources/config/defaults.inc.php
+++ b/src/CoreBundle/Resources/config/defaults.inc.php
@@ -54,11 +54,11 @@ if (!defined('PATH_CMS_UPDATE')) {
  * CMS customer data path.
  */
 if (!defined('PATH_CMS_CUSTOMER_DATA')) {
-    define('PATH_CMS_CUSTOMER_DATA', PATH_PROJECT_BASE.'/app/cmsdata/');
+    define('PATH_CMS_CUSTOMER_DATA', PATH_PROJECT_BASE.'/var/cmsdata/');
 }
 
 if (!defined('PATH_CACHE')) {
-    define('PATH_CACHE', PATH_PROJECT_BASE.'/app/cache/');
+    define('PATH_CACHE', PATH_PROJECT_BASE.'/var/cache/');
 }
 /**
  * path to the customer pagelayouts

--- a/src/CoreBundle/Resources/config/project-config.yml
+++ b/src/CoreBundle/Resources/config/project-config.yml
@@ -57,28 +57,20 @@ parameters:
 
   chameleon_system_external_tracker_google_analytics.enable_campaign_tracking: false # if true, the product exports will add their google campaign parameters (if they support them) to the detail links of the products
 
-  database_port: 3306
+  database_host: "" # @deprecated since 6.3.0 - no longer used
+  database_port: 3306 # @deprecated since 6.3.0 - no longer used
+  database_name: "" # @deprecated since 6.3.0 - no longer used
+  database_user: "" # @deprecated since 6.3.0 - no longer used
+  database_password: "" # @deprecated since 6.3.0 - no longer used
 
   twig.exception_listener.class: ChameleonSystem\CoreBundle\EventListener\ChameleonExceptionListener
 
   chameleon_system_core.google.api_key: ''
 
-chameleon_system_core:
-    mailer:
-      host: "%mailer_host%"
-      user: "%mailer_user%"
-      password: "%mailer_password%"
-    mail_target_transformation_service:
-      target_mail: "%chameleon_system_core.mail_target_transformation_service.target_mail%"
-      enabled: "%chameleon_system_core.mail_target_transformation_service.enabled%"
-      subject_prefix: "%chameleon_system_core.mail_target_transformation_service.subject_prefix%"
-      white_list: "%chameleon_system_core.mail_target_transformation_service.white_list%"
-
 framework:
   csrf_protection: ~
-  validation:      { enable_annotations: true }
+  validation: ~
   router:
-    resource: "%kernel.root_dir%/config/routing.yml"
     strict_requirements: ~
   session:
     metadata_update_threshold: 120

--- a/src/CoreBundle/Resources/config/project-config_dev.yml
+++ b/src/CoreBundle/Resources/config/project-config_dev.yml
@@ -6,12 +6,13 @@ parameters:
   chameleon_system_core.cache.default_max_age_in_seconds: 60
   chameleon_system_core.cache.cache_less_files: false
 
+  chameleon_system_core.debug.show_view_source_html_hints: true
+
   chameleon_system_core.resources.enable_external_resource_collection: false
   chameleon_system_core.resources.enable_external_resource_collection_minify: false
 
 framework:
   router:
-    resource: "%kernel.root_dir%/config/routing_dev.yml"
     strict_requirements: true
   profiler: { only_exceptions: false }
   session:

--- a/src/CoreBundle/Resources/config/project-config_test.yml
+++ b/src/CoreBundle/Resources/config/project-config_test.yml
@@ -1,22 +1,23 @@
 imports:
-   - { resource: project-config.yml }
+     - { resource: project-config.yml }
 
 parameters:
-  chameleon_system_core.cache.allow: false
-  chameleon_system_core.cache.default_max_age_in_seconds: 60
+    chameleon_system_core.cache.allow: false
+    chameleon_system_core.cache.default_max_age_in_seconds: 60
 
-  chameleon_system_core.resources.enable_external_resource_collection: false
+    chameleon_system_core.debug.show_view_source_html_hints: true
+
+    chameleon_system_core.resources.enable_external_resource_collection: false
 
 framework:
-  router:
-    resource: "%kernel.root_dir%/config/routing_dev.yml"
-    strict_requirements: true
-  profiler: { only_exceptions: false }
-  test: true
+    router:
+        strict_requirements: true
+    profiler: { only_exceptions: false }
+    test: true
 
 web_profiler:
     toolbar: false
     intercept_redirects: false
 
 chameleon_system_core:
-  redirectstrategy: "throwexception"
+    redirectstrategy: "throwexception"

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="vendor_dir">%kernel.root_dir%/../vendors</parameter>
+        <parameter key="vendor_dir">%kernel.project_dir%/vendor</parameter>
         <parameter key="chameleon_system_core.pdo.mysql_attr_init_command" type="constant">\PDO::MYSQL_ATTR_INIT_COMMAND</parameter>
         <parameter key="chameleon_system_core.pdo.mysql_attr_compression_name" type="constant">\PDO::MYSQL_ATTR_COMPRESS</parameter>
         <parameter key="chameleon_system_core.pdo.enable_mysql_compression">false</parameter>
@@ -15,30 +15,8 @@
     </parameters>
 
     <services>
-        <service id="chameleon_system_core.pdo" class="PDO" public="false">
-            <argument>mysql:dbname=%database_name%;host=%database_host%;port=%database_port%;charset=utf8</argument>
-            <argument>%database_user%</argument>
-            <argument>%database_password%</argument>
-            <argument type="collection">
-                <argument key="%chameleon_system_core.pdo.mysql_attr_init_command%">SET NAMES utf8</argument>
-                <argument key="%chameleon_system_core.pdo.mysql_attr_compression_name%">%chameleon_system_core.pdo.enable_mysql_compression%</argument>
-            </argument>
-            <call method="setAttribute">
-                <argument type="constant">\PDO::ATTR_ERRMODE</argument>
-                <argument type="constant">\PDO::ERRMODE_EXCEPTION</argument>
-            </call>
-        </service>
-
-        <service id="chameleon_system_core.sessionPdo" alias="chameleon_system_core.pdo" />
-
-        <service id="database_connection" class="Doctrine\DBAL\Connection" public="true">
-            <factory class="Doctrine\DBAL\DriverManager" method="getConnection" />
-            <argument type="collection">
-                <argument key="driver">pdo_mysql</argument>
-                <argument key="pdo" type="service" id="chameleon_system_core.pdo" />
-                <argument key="charset">UTF8</argument>
-                <argument key="logging" type="service" id="cmsPkgCore.logChannel.dbal" />
-            </argument>
+        <service id="chameleon_system_core.sessionPdo" class="PDO">
+            <factory service="database_connection" method="getWrappedConnection" />
         </service>
 
         <service id="chameleon_system_core.global" class="TGlobal" public="true">

--- a/src/CoreBundle/bin/console
+++ b/src/CoreBundle/bin/console
@@ -1,23 +1,36 @@
 #!/usr/bin/php
 <?php
 
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Debug\Debug;
+
 set_time_limit(0);
+
+require __DIR__.'/../../../../../../vendor/autoload.php';
 
 /**
  * set $_SERVER vars manually, as they are not available in console.
  */
-$_SERVER['DOCUMENT_ROOT'] = realpath(__DIR__.'/../../../../../../web');
+$_SERVER['DOCUMENT_ROOT'] = realpath(__DIR__.'/../../../../../../public');
 $_SERVER['HTTP_HOST'] = 'you-have-no-host-because-you-are-in-console.com';
 define('REQUEST_PROTOCOL', 'console');
 
 define('PATH_WEB', $_SERVER['DOCUMENT_ROOT']);
 require_once __DIR__.'/../Resources/config/const.inc.php';
 
-if (file_exists(PATH_PROJECT_BASE.'/app/autoload.php')) {
-    include_once PATH_PROJECT_BASE.'/app/autoload.php';
-} else {
-    include_once __DIR__.'/../../../../../autoload.php';
+$input = new ArgvInput();
+if (null !== $_ENV['APP_ENV'] = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_ENV['APP_ENV']);
+    // force loading .env files when --env is defined
+    $_SERVER['APP_ENV'] = null;
 }
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+require __DIR__.'/../../../../../../src/.bootstrap.php';
 
 require_once PATH_PROJECT_CONFIG.'/config.inc.php';
 require_once PATH_CORE_CONFIG.'/config.inc.php';
@@ -27,20 +40,14 @@ spl_autoload_register('ChameleonSystem\AutoclassesBundle\Loader\AutoClassLoader:
 
 TGlobal::setMode(TGlobal::MODE_BACKEND);
 
-require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
+if (true === $_SERVER['APP_DEBUG']) {
+    umask(0000);
 
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
-
-$input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
-$debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('--no-debug', '')) && 'prod' !== $env;
-
-try {
-    $kernel = new AppKernel($env, $debug);
-    $application = new Application($kernel);
-    $application->setCatchExceptions(false);
-    $application->run($input);
-} catch (Exception $e) {
-    echo $e;
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
 }
+
+$kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
+$application = new Application($kernel);
+$application->run($input);

--- a/src/CoreBundle/private/core/TGlobalBase.class.php
+++ b/src/CoreBundle/private/core/TGlobalBase.class.php
@@ -1024,8 +1024,7 @@ class TGlobalBase
     public static function TableExists($sTableName)
     {
         $databaseConnection = self::getDatabaseConnection();
-        $databaseName = \ChameleonSystem\CoreBundle\ServiceLocator::getParameter('database_name');
-        $quotedDatabaseName = $databaseConnection->quoteIdentifier($databaseName);
+        $quotedDatabaseName = $databaseConnection->quoteIdentifier($databaseConnection->getDatabase());
         $query = "SHOW TABLES FROM $quotedDatabaseName LIKE :tableName";
         $tRes = $databaseConnection->executeQuery($query, array('tableName' => $sTableName));
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableWriter.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableWriter.class.php
@@ -427,7 +427,7 @@ class TCMSTableWriter extends TCMSTableEditor
 
         $databaseConnection = $this->getDatabaseConnection();
         $engine = $databaseConnection->fetchColumn($query, [
-            'databaseName' => ServiceLocator::getParameter('database_name'),
+            'databaseName' => $databaseConnection->getDatabase(),
             'tableName' => $tableName,
         ]);
         if (false === $engine) {

--- a/src/DebugBundle/DependencyInjection/ChameleonSystemDebugExtension.php
+++ b/src/DebugBundle/DependencyInjection/ChameleonSystemDebugExtension.php
@@ -25,6 +25,12 @@ class ChameleonSystemDebugExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/'));
         $loader->load('services.xml');
 
+        if (false === $config['database_profiler_enabled']) {
+            return;
+        }
+
+        $loader->load('database_profiler.xml');
+
         foreach (array($container->getDefinition('chameleon_system_debug.database_collector'),
                     $container->getDefinition('chameleon_system_debug.profiler_database_connection'), ) as $definition) {
             $definition->addMethodCall('setBacktraceEnabled', array($config['backtrace_enabled']));

--- a/src/DebugBundle/DependencyInjection/Configuration.php
+++ b/src/DebugBundle/DependencyInjection/Configuration.php
@@ -28,6 +28,9 @@ class Configuration implements ConfigurationInterface
 
         $root
             ->children()
+                ->booleanNode('database_profiler_enabled')
+                    ->defaultFalse()
+                ->end()
                 ->booleanNode('backtrace_enabled')
                     ->defaultFalse()
                 ->end()

--- a/src/DebugBundle/Resources/config/database_profiler.xml
+++ b/src/DebugBundle/Resources/config/database_profiler.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="chameleon_system_debug.profiler_database_connection" class="ChameleonSystem\DebugBundle\Connection\ProfilerDatabaseConnection" decorates="database_connection">
+            <argument type="service" id="chameleon_system_debug.profiler_database_connection.inner" />
+        </service>
+
+        <service id="chameleon_system_debug.database_collector" class="ChameleonSystem\DebugBundle\Collector\DatabaseDataCollector">
+            <argument type="service" id="chameleon_system_debug.profiler_database_connection" />
+            <tag name="data_collector" template="ChameleonSystemDebugBundle:Profiler:layout" id="chameleon.database" />
+        </service>
+    </services>
+</container>

--- a/src/DebugBundle/Resources/config/services.xml
+++ b/src/DebugBundle/Resources/config/services.xml
@@ -4,20 +4,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-
-        <service id="chameleon_system_debug.profiler_database_connection" class="ChameleonSystem\DebugBundle\Connection\ProfilerDatabaseConnection" decorates="database_connection">
-            <argument type="service" id="chameleon_system_debug.profiler_database_connection.inner" />
-        </service>
-
-        <service id="chameleon_system_debug.database_collector" class="ChameleonSystem\DebugBundle\Collector\DatabaseDataCollector">
-            <argument type="service" id="chameleon_system_debug.profiler_database_connection" />
-            <tag name="data_collector" template="ChameleonSystemDebugBundle:Profiler:layout" id="chameleon.database" />
-        </service>
-
         <service id="chameleon_system_debug.debug_test_session_locking_controller" class="ChameleonSystem\DebugBundle\Controller\DebugTestSessionLockingController">
             <argument type="service" id="session" />
             <argument type="service" id="router" />
         </service>
-
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#94
| License       | MIT

A WIP PR for introducing Symfony Flex. Another PR was filed for chameleon-system/chameleon-system (https://github.com/chameleon-system/chameleon-system/pull/209).

We should first review the changes to see if they are OK, i.e. are the BC breaks tolerable for 6.3 or if we should wait for 7.0. 
Then there are further tasks:
- Write deprecation notes to the UPGRADING file.
- Write migration notes to the UPGRADING file. Some of the required Composer and file changes should be handled by a migration script to simplify the migration.
- Write notes to the CHANGELOG file.

Mostly this is a "simple" switch to Flex, but also I use the Doctrine bundle so that we can get rid of some services in CoreBundle's services.xml, be closer to the Symfony standard, avoid some environment variables, and gain the Doctrine debug toolbar profiler. The old Chameleon database profiler is now disabled by default, but otherwise left untouched, as it might provide other information than the Doctrine profiler.