### PR TITLE
Fix/Unmanaged List Table Handling

### DIFF
--- a/src/CoreBundle/private/library/classes/HTMLParser/HTMLParser.class.php
+++ b/src/CoreBundle/private/library/classes/HTMLParser/HTMLParser.class.php
@@ -252,7 +252,7 @@ class HtmlParser
 
     public function skipEndOfTag()
     {
-        while (($ch = $this->iCurrentChar) !== -1) {
+        while (-1 !== ($ch = $this->iCurrentChar)) {
             if ('>' == $ch) {
                 $this->moveNext();
 
@@ -265,7 +265,7 @@ class HtmlParser
     public function skipInTag($chars)
     {
         $sb = '';
-        while (($ch = $this->iCurrentChar) !== -1) {
+        while (-1 !== ($ch = $this->iCurrentChar)) {
             if ('>' == $ch) {
                 return $sb;
             } else {
@@ -291,7 +291,7 @@ class HtmlParser
     {
         $sb = '';
         $count = 0;
-        while (($ch = $this->iCurrentChar) !== -1 && $count++ < $maxChars) {
+        while (-1 !== ($ch = $this->iCurrentChar) && $count++ < $maxChars) {
             if ('>' == $ch) {
                 return $sb;
             } else {
@@ -316,7 +316,7 @@ class HtmlParser
     public function skipToInTag($chars)
     {
         $sb = '';
-        while (($ch = $this->iCurrentChar) !== -1) {
+        while (-1 !== ($ch = $this->iCurrentChar)) {
             $match = '>' == $ch;
             if (!$match) {
                 for ($idx = 0; $idx < count($chars); ++$idx) {
@@ -339,7 +339,7 @@ class HtmlParser
     public function skipToElement()
     {
         $sb = '';
-        while (($ch = $this->iCurrentChar) !== -1) {
+        while (-1 !== ($ch = $this->iCurrentChar)) {
             if ('<' == $ch) {
                 return $sb;
             }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCMSUser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCMSUser.class.php
@@ -75,6 +75,13 @@ class TCMSListManagerCMSUser extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCMSUser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCMSUser.class.php
@@ -75,9 +75,10 @@ class TCMSListManagerCMSUser extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCmsTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCmsTableConf.class.php
@@ -16,9 +16,10 @@ class TCMSListManagerCmsTableConf extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCmsTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerCmsTableConf.class.php
@@ -14,4 +14,11 @@ class TCMSListManagerCmsTableConf extends TCMSListManagerFullGroupTable
     public function _AddFunctionColumn()
     {
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentChooser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentChooser.class.php
@@ -168,4 +168,12 @@ class TCMSListManagerDocumentChooser extends TCMSListManagerFullGroupTable
 
         return $html;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentChooser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentChooser.class.php
@@ -170,10 +170,10 @@ class TCMSListManagerDocumentChooser extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManager.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManager.class.php
@@ -182,9 +182,10 @@ class TCMSListManagerDocumentManager extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManager.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManager.class.php
@@ -182,6 +182,13 @@ class TCMSListManagerDocumentManager extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManagerSelected.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManagerSelected.class.php
@@ -173,6 +173,13 @@ class TCMSListManagerDocumentManagerSelected extends TCMSListManagerFullGroupTab
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManagerSelected.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerDocumentManagerSelected.class.php
@@ -173,9 +173,10 @@ class TCMSListManagerDocumentManagerSelected extends TCMSListManagerFullGroupTab
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerEndPoint.class.php
@@ -545,6 +545,13 @@ class TCMSListManagerEndPoint
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerEndPoint.class.php
@@ -544,10 +544,8 @@ class TCMSListManagerEndPoint
         return $aAdditionalParameterData;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookup.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookup.class.php
@@ -56,9 +56,10 @@ class TCMSListManagerExtendedLookup extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookup.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookup.class.php
@@ -56,6 +56,13 @@ class TCMSListManagerExtendedLookup extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * add table-specific buttons to the editor (add them directly to $this->oMenuItems).
      */
     protected function GetCustomMenuItems()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookupModuleInstance.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookupModuleInstance.class.php
@@ -39,10 +39,10 @@ class TCMSListManagerExtendedLookupModuleInstance extends TCMSListManagerModuleI
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookupModuleInstance.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerExtendedLookupModuleInstance.class.php
@@ -37,4 +37,12 @@ class TCMSListManagerExtendedLookupModuleInstance extends TCMSListManagerModuleI
 
         return $aIncludes;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
@@ -99,6 +99,8 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
             $this->PostCreateTableObjectHook();
         }
 
+        $this->tableObj->isManagedTable = $this->usesManagedTables();
+
         if (($objectChangeRequest || is_null($oOldTableObj)) && $this->bListCacheEnabled && CMS_ACTIVE_BACKEND_LIST_CACHE) {
             $tmp = serialize($this->tableObj);
             $tmp = gzcompress($tmp, 9);

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
@@ -74,6 +74,7 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
         // table is not in cache, load it
         if (is_null($oOldTableObj) || false === $oOldTableObj) {
             $this->CreateTableObj();
+            $this->tableObj->isManagedTable = $this->usesManagedTables();
             $this->tableObj->orderList = $aOrderData;
             $this->AddFields();
             $this->AddSortInformation();
@@ -98,8 +99,6 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
 
             $this->PostCreateTableObjectHook();
         }
-
-        $this->tableObj->isManagedTable = $this->usesManagedTables();
 
         if (($objectChangeRequest || is_null($oOldTableObj)) && $this->bListCacheEnabled && CMS_ACTIVE_BACKEND_LIST_CACHE) {
             $tmp = serialize($this->tableObj);

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
@@ -872,6 +872,17 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
     }
 
     /**
+     * Decides if table instances created by this list manager are managed, receiving data attributes with table metadata
+     * for client-side management, overlay- and inline editing features. Subclasses to list managers with special functionality
+     * may disable table management, particularly when not using a table function bar (see "_AddFunctionColumn").
+     *
+     * @return bool
+     */
+    protected function usesManagedTables(): bool {
+        return true;
+    }
+
+    /**
      * tests, whether $row has a workflow_action and the record is part of the
      * current workflow transaction
      * returns always true on tables without activated transaction handling.

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
@@ -879,7 +879,8 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
      *
      * @return bool
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return true;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImageMLTList.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImageMLTList.class.php
@@ -58,4 +58,12 @@ class TCMSListManagerImageMLTList extends TCMSListManagerMLTList
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImageMLTList.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImageMLTList.class.php
@@ -60,10 +60,10 @@ class TCMSListManagerImageMLTList extends TCMSListManagerMLTList
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabase.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabase.class.php
@@ -61,10 +61,10 @@ class TCMSListManagerImagedatabase extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabase.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabase.class.php
@@ -59,4 +59,12 @@ class TCMSListManagerImagedatabase extends TCMSListManagerFullGroupTable
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabaseMLT.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabaseMLT.class.php
@@ -55,4 +55,12 @@ class TCMSListManagerImagedatabaseMLT extends TCMSListManagerMLT
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabaseMLT.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerImagedatabaseMLT.class.php
@@ -57,10 +57,10 @@ class TCMSListManagerImagedatabaseMLT extends TCMSListManagerMLT
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLT.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLT.class.php
@@ -220,9 +220,10 @@ class TCMSListManagerMLT extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLT.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLT.class.php
@@ -220,6 +220,13 @@ class TCMSListManagerMLT extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLTList.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLTList.class.php
@@ -114,6 +114,13 @@ class TCMSListManagerMLTList extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLTList.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMLTList.class.php
@@ -114,9 +114,10 @@ class TCMSListManagerMLTList extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaManager.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaManager.class.php
@@ -61,10 +61,10 @@ class TCMSListManagerMediaManager extends TCMSListManagerImagedatabase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaManager.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaManager.class.php
@@ -59,4 +59,12 @@ class TCMSListManagerMediaManager extends TCMSListManagerImagedatabase
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaSelector.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaSelector.class.php
@@ -275,6 +275,13 @@ class TCMSListManagerMediaSelector extends TCMSListManagerImagedatabase
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaSelector.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerMediaSelector.class.php
@@ -275,9 +275,10 @@ class TCMSListManagerMediaSelector extends TCMSListManagerImagedatabase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerModuleInstanceEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerModuleInstanceEndPoint.class.php
@@ -164,6 +164,13 @@ class TCMSListManagerModuleInstanceEndPoint extends TCMSListManagerFullGroupTabl
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return Connection
      */
     private function getDatabaseConnection()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerModuleInstanceEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerModuleInstanceEndPoint.class.php
@@ -164,9 +164,10 @@ class TCMSListManagerModuleInstanceEndPoint extends TCMSListManagerFullGroupTabl
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPagedefinitions.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPagedefinitions.class.php
@@ -49,4 +49,12 @@ class TCMSListManagerPagedefinitions extends TCMSListManagerFullGroupTable
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPagedefinitions.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPagedefinitions.class.php
@@ -51,10 +51,10 @@ class TCMSListManagerPagedefinitions extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPortalDomains.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPortalDomains.class.php
@@ -34,6 +34,13 @@ class TCMSListManagerPortalDomains extends TCMSListManagerFullGroupTable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
+    /**
      * @return TranslatorInterface
      */
     private function getTranslator()

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPortalDomains.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerPortalDomains.class.php
@@ -34,9 +34,10 @@ class TCMSListManagerPortalDomains extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerTreeNode.class.php
@@ -149,4 +149,12 @@ class TCMSListManagerTreeNode extends TCMSListManagerFullGroupTable
         $this->tableObj->orderList['active'] = 'DESC';
         $this->tableObj->orderList['start_date'] = 'ASC';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerTreeNode.class.php
@@ -151,10 +151,10 @@ class TCMSListManagerTreeNode extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWYSIWYGImage.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWYSIWYGImage.class.php
@@ -174,4 +174,12 @@ class TCMSListManagerWYSIWYGImage extends TCMSListManagerImagedatabase
         $this->oMenuItems->RemoveItem('sItemKey', 'deleteall');
         $this->oMenuItems->RemoveItem('sItemKey', 'edittableconf');
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWYSIWYGImage.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWYSIWYGImage.class.php
@@ -176,10 +176,10 @@ class TCMSListManagerWYSIWYGImage extends TCMSListManagerImagedatabase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWebpages.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWebpages.class.php
@@ -87,10 +87,10 @@ class TCMSListManagerWebpages extends TCMSListManagerFullGroupTable
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    protected function usesManagedTables(): bool {
+    protected function usesManagedTables(): bool
+    {
         return false;
     }
-
 }

--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWebpages.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerWebpages.class.php
@@ -85,4 +85,12 @@ class TCMSListManagerWebpages extends TCMSListManagerFullGroupTable
 
         return $aItems;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function usesManagedTables(): bool {
+        return false;
+    }
+
 }

--- a/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
@@ -241,6 +241,14 @@ class TFullGroupTable extends TGroupTable
     public $sPagingSection = '';
 
     /**
+     *
+     * the table is managed by client-side modules, should receive data attributes with table metadata.
+     *
+     * @var bool
+     */
+    public $isManagedTable = false;
+
+    /**
      * CSS classes for the table tag.
      *
      * @var string
@@ -371,6 +379,10 @@ class TFullGroupTable extends TGroupTable
      */
     private function getManagedAttributes()
     {
+        if (false === $this->isManagedTable) {
+            return [];
+        }
+
         $inputFilterUtil = $this->getInputFilterUtil();
         $tableConfigurationId = $inputFilterUtil->getFilteredInput('id');
         $tableEditorConfId = TTools::GetCMSTableId('cms_tbl_conf');

--- a/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
@@ -241,14 +241,6 @@ class TFullGroupTable extends TGroupTable
     public $sPagingSection = '';
 
     /**
-     *
-     * the table is managed by client-side modules, should receive data attributes with table metadata.
-     *
-     * @var bool
-     */
-    public $isManagedTable = false;
-
-    /**
      * CSS classes for the table tag.
      *
      * @var string

--- a/src/CoreBundle/private/library/classes/TGroupTable/TGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TGroupTable/TGroupTable.class.php
@@ -138,7 +138,6 @@ class TGroupTable
     public $rowCallback = null;
 
     /**
-     *
      * the table is managed by client-side modules, should receive data attributes with table metadata.
      *
      * @var bool

--- a/src/CoreBundle/private/library/classes/TGroupTable/TGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TGroupTable/TGroupTable.class.php
@@ -138,6 +138,14 @@ class TGroupTable
     public $rowCallback = null;
 
     /**
+     *
+     * the table is managed by client-side modules, should receive data attributes with table metadata.
+     *
+     * @var bool
+     */
+    public $isManagedTable = false;
+
+    /**
      * you may fill this via $this->table->SetCustomOrderString($sMyOrderString);
      * if a custom order string is set _GetOrderString() uses this
      * instead of generating it based on current configured order fields.
@@ -165,7 +173,7 @@ class TGroupTable
      */
     public function AddGroupField($name, $align = 'left', $format = null, $linkField = null, $colSpan = 1, $selectFormat = null)
     {
-        $this->groupByCell = new TGroupTableField($name, $align, $format, $linkField, $colSpan, $selectFormat);
+        $this->groupByCell = new TGroupTableField($name, $align, $format, $linkField, $colSpan, $selectFormat, null, null, null, $this->isManagedTable);
     }
 
     /**
@@ -196,7 +204,7 @@ class TGroupTable
     public function AddColumn($name, $align = 'left', $formatCallBack = null, $linkField = null, $colSpan = 1, $selectFormat = null, $sIdent = null, $columnPosition = null, $originalField = null, $originalTable = null)
     {
         $this->_columnCount += $colSpan;
-        $oField = new TGroupTableField($name, $align, $formatCallBack, $linkField, $colSpan, $selectFormat, $sIdent, $originalField, $originalTable);
+        $oField = new TGroupTableField($name, $align, $formatCallBack, $linkField, $colSpan, $selectFormat, $sIdent, $originalField, $originalTable, $this->isManagedTable);
 
         if (null !== $columnPosition && count($this->columnList) > 0) {
             $count = 0;

--- a/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
+++ b/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
@@ -92,21 +92,29 @@ class TGroupTableField
     public $originalTable;
 
     /**
+     * Management status of table class owning table field.
+     *
+     * @var bool
+     */
+    public $tableIsManaged = false;
+
+    /**
      * Table cell configuration.
      *
-     * @param string|array  $name           - if it is an array it should be of the form 'name'=>'full_name'
-     * @param string        $align
+     * @param string|array $name - if it is an array it should be of the form 'name'=>'full_name'
+     * @param string $align
      * @param resource|null $formatCallBack - a callback function to use for the column (the function will get 2 parameters,
      *                                      the value, and the row. The string returned by the function will be displayed
      *                                      in the cell
-     * @param array|null    $linkFields
-     * @param int           $colSpan
-     * @param object|null   $selectFormat   - callback function for option titles
-     * @param string|null   $ident
-     * @param string|null   $originalField
-     * @param string|null   $originalTable
+     * @param array|null $linkFields
+     * @param int $colSpan
+     * @param object|null $selectFormat - callback function for option titles
+     * @param string|null $ident
+     * @param string|null $originalField
+     * @param string|null $originalTable
+     * @param bool $tableIsManaged
      */
-    public function __construct($name, $align = 'left', $formatCallBack = null, $linkFields = null, $colSpan = 1, $selectFormat = null, $ident = null, $originalField = null, $originalTable = null)
+    public function __construct($name, $align = 'left', $formatCallBack = null, $linkFields = null, $colSpan = 1, $selectFormat = null, $ident = null, $originalField = null, $originalTable = null, $tableIsManaged = false)
     {
         if (is_array($name)) {
             $tkey = array_keys($name);
@@ -117,16 +125,20 @@ class TGroupTableField
             $this->name = $name;
             $this->full_db_name = $this->name;
         }
+
         if (null === $originalField) {
             $originalField = $this->name;
         }
+
         $this->originalTable = $originalTable;
+        $this->tableIsManaged = $tableIsManaged;
         $this->sOriginalField = $originalField;
         $this->align = $align;
         $this->format = $formatCallBack;
         $this->linkFields = $linkFields;
         $this->colSpan = $colSpan;
         $this->selectFormat = $selectFormat;
+
         if (null !== $ident) {
             $this->sIdent = $ident;
         } else {

--- a/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
+++ b/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
@@ -101,18 +101,18 @@ class TGroupTableField
     /**
      * Table cell configuration.
      *
-     * @param string|array $name - if it is an array it should be of the form 'name'=>'full_name'
-     * @param string $align
+     * @param string|array  $name           - if it is an array it should be of the form 'name'=>'full_name'
+     * @param string        $align
      * @param resource|null $formatCallBack - a callback function to use for the column (the function will get 2 parameters,
      *                                      the value, and the row. The string returned by the function will be displayed
      *                                      in the cell
-     * @param array|null $linkFields
-     * @param int $colSpan
-     * @param object|null $selectFormat - callback function for option titles
-     * @param string|null $ident
-     * @param string|null $originalField
-     * @param string|null $originalTable
-     * @param bool $tableIsManaged
+     * @param array|null    $linkFields
+     * @param int           $colSpan
+     * @param object|null   $selectFormat   - callback function for option titles
+     * @param string|null   $ident
+     * @param string|null   $originalField
+     * @param string|null   $originalTable
+     * @param bool          $tableIsManaged
      */
     public function __construct($name, $align = 'left', $formatCallBack = null, $linkFields = null, $colSpan = 1, $selectFormat = null, $ident = null, $originalField = null, $originalTable = null, $tableIsManaged = false)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | no
| License       | MIT

Provides supplementary changes provided for overlay- and inline editing introduced by commits up to `77d134fe1f9dfdeb96353d5dcd621fe14588f667` of the `chameleon-system/inline-editing-bundle`, currently in review.

Add `TCMSListManager` support-indicative function `usesManagedTables(): bool`. Returned value is forwarded to all created tables (`TGroupTable`, `TFullGroupTable`, ...) as `isManagedTable` and passed along to created table fields with `tableIsManaged`.

The event emitted by table fields includes a reference to the field, allowing determining if it is owned by a managed table. All transformations performed by the inline editing bundle are *no longer applied* when encountering a field that does not belong to a table with the `*isManaged` state.