### PR TITLE
ref #216: add missing page number value to ajax data

### DIFF
--- a/src/MediaManagerBundle/Resources/public/js/mediaManager.js
+++ b/src/MediaManagerBundle/Resources/public/js/mediaManager.js
@@ -336,6 +336,7 @@
                 url: url,
                 data: {
                     'ps': state.pageSize,
+                    'p': state.pageNumber,
                     's': state.searchTerm,
                     'mediaTreeId': state.mediaTreeNodeId,
                     'listView': state.listView,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#216
| License       | MIT

Adds the mising pageNumber to ajax call for image list rendering.