### PR TITLE
ref #108: Do not set fixed heights for media manager or popups

### DIFF
--- a/src/MediaManagerBundle/Resources/public/css/mediaManager.css
+++ b/src/MediaManagerBundle/Resources/public/css/mediaManager.css
@@ -11,7 +11,6 @@
 
 .snippetMediaManagerBackendModuleStandard {
     background: #fff;
-    position: relative;
 }
 
 .snippetMediaManagerBackendModuleStandard:after {

--- a/src/MediaManagerBundle/Resources/public/css/mediaManager.less
+++ b/src/MediaManagerBundle/Resources/public/css/mediaManager.less
@@ -11,7 +11,6 @@
 
 .snippetMediaManagerBackendModuleStandard {
   background: #fff;
-  position: relative;
   &:after {
     content: " ";
     clear: both;

--- a/src/MediaManagerBundle/Resources/public/js/mediaManager.js
+++ b/src/MediaManagerBundle/Resources/public/js/mediaManager.js
@@ -1029,14 +1029,6 @@
             var closeButton = $('<span class="close-button">' + CHAMELEON.CORE.i18n.Translate('chameleon_system_media_manager.close_button_text') + ' <span class="glyphicon glyphicon-remove"></span></span>');
             var layover = $('<div class="media-manager-layover"><div class="title h3">' + title + '</div></div>');
 
-            var newHeight = $(window).height() - this.editContainer.offset().top;
-            if (newHeight < this.element.height()) {
-                newHeight = this.element.height();
-            }
-
-            console.log("Setting height "+newHeight);
-
-            //layover.css({'height': newHeight, 'width': '100%'});
             closeButton.on('click', function (evt) {
                 self.showWaitingAnimation();
                 layover.remove();

--- a/src/MediaManagerBundle/Resources/public/js/mediaManager.js
+++ b/src/MediaManagerBundle/Resources/public/js/mediaManager.js
@@ -198,9 +198,7 @@
                 .one('state_ready.jstree', self.onTreeRestoredState.bind(this))
             ;
 
-            self.element.css('height', $(window).height() - 10);
             $(window).on('resize', function () {
-                self.element.css('height', $(window).height() - 10);
                 $('.gutter-horizontal', self.element).css('height', self.element.height());
             });
 
@@ -1036,7 +1034,9 @@
                 newHeight = this.element.height();
             }
 
-            layover.css({'height': newHeight, 'width': '100%'});
+            console.log("Setting height "+newHeight);
+
+            //layover.css({'height': newHeight, 'width': '100%'});
             closeButton.on('click', function (evt) {
                 self.showWaitingAnimation();
                 layover.remove();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#108
| License       | MIT

Without fixed heights this looks good/ok:
For the default of 204 images per page the media manager page is rather high. But this is handled by the browser scrollbar.
Other views with fewer images are then only as high as needed.

This also looks ok when selecting an image for some image field.