### PR TITLE
ref #190: Remove custom Twig translation

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -274,6 +274,8 @@ is recommended (although this tool may not find database-related deprecations).
 
 - \IPkgCmsCoreLog
 - \TPkgCmsCoreLog
+- \TPkgSnippetRenderer_TranslationNode
+- \TPkgSnippetRenderer_TranslationTokenParser
 
 ## Properties
 

--- a/src/SnippetRendererBundle/objects/customTags/TPkgSnippetRenderer_TranslationNode.class.php
+++ b/src/SnippetRendererBundle/objects/customTags/TPkgSnippetRenderer_TranslationNode.class.php
@@ -11,10 +11,12 @@
 
 /**
  * the class is based on / copied from the symfony TransNode class.
+ *
+ * @deprecated since 6.3.0 - no longer used.
 /**/
 class TPkgSnippetRenderer_TranslationNode extends Twig_Node
 {
-    public function __construct(\Twig_NodeInterface $body, \Twig_NodeInterface $domain, \Twig_Node_Expression $count = null, \Twig_Node_Expression $vars = null, \Twig_Node_Expression $locale = null, $lineno = 0, $tag = null)
+    public function __construct(\Twig_Node $body, \Twig_Node $domain, \Twig_Node_Expression $count = null, \Twig_Node_Expression $vars = null, \Twig_Node_Expression $locale = null, $lineno = 0, $tag = null)
     {
         parent::__construct(array('count' => $count, 'body' => $body, 'domain' => $domain, 'vars' => $vars, 'locale' => $locale), array(), $lineno, $tag);
     }
@@ -58,7 +60,7 @@ class TPkgSnippetRenderer_TranslationNode extends Twig_Node
         $compiler->raw(");\n");
     }
 
-    protected function compileString(\Twig_NodeInterface $body, \Twig_Node_Expression_Array $vars)
+    protected function compileString(\Twig_Node $body, \Twig_Node_Expression_Array $vars)
     {
         if ($body instanceof \Twig_Node_Expression_Constant) {
             $msg = $body->getAttribute('value');

--- a/src/SnippetRendererBundle/objects/customTags/TPkgSnippetRenderer_TranslationTokenParser.class.php
+++ b/src/SnippetRendererBundle/objects/customTags/TPkgSnippetRenderer_TranslationTokenParser.class.php
@@ -10,16 +10,14 @@
  */
 
 /**
- *  The class is based (copied) from the symfony TransTokenParser class.
-/**/
+ * The class is based (copied) from the symfony TransTokenParser class.
+ *
+ * @deprecated since 6.3.0 - no longer used.
+ */
 class TPkgSnippetRenderer_TranslationTokenParser extends Twig_TokenParser
 {
     /**
-     * Parses a token and returns a node.
-     *
-     * @param \Twig_Token $token A Twig_Token instance
-     *
-     * @return \Twig_NodeInterface A Twig_NodeInterface instance
+     * {@inheritdoc}
      */
     public function parse(\Twig_Token $token)
     {

--- a/src/TwigDebugBundle/Twig/Parser/IncludeNodeParser.php
+++ b/src/TwigDebugBundle/Twig/Parser/IncludeNodeParser.php
@@ -12,22 +12,13 @@
 namespace ChameleonSystem\TwigDebugBundle\Twig\Parser;
 
 use ChameleonSystem\TwigDebugBundle\Twig\Node\Twig_Node_Include_Decorator;
-use Twig_Error_Syntax;
-use Twig_NodeInterface;
-use Twig_Token;
 
 class IncludeNodeParser extends \Twig_TokenParser_Include
 {
     /**
-     * Parses a token and returns a node.
-     *
-     * @param Twig_Token $token A Twig_Token instance
-     *
-     * @return Twig_NodeInterface A Twig_NodeInterface instance
-     *
-     * @throws Twig_Error_Syntax
+     * {@inheritdoc}
      */
-    public function parse(Twig_Token $token)
+    public function parse(\Twig_Token $token)
     {
         $node = parent::parse($token);
 

--- a/src/ViewRendererBundle/Twig/Extension/ChameleonStandardExtension.php
+++ b/src/ViewRendererBundle/Twig/Extension/ChameleonStandardExtension.php
@@ -12,7 +12,6 @@
 namespace ChameleonSystem\ViewRendererBundle\Twig\Extension;
 
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
-use TPkgSnippetRenderer_TranslationTokenParser;
 use Twig_Environment;
 use Twig_SimpleFilter;
 

--- a/src/ViewRendererBundle/Twig/Extension/ChameleonStandardExtension.php
+++ b/src/ViewRendererBundle/Twig/Extension/ChameleonStandardExtension.php
@@ -56,13 +56,6 @@ class ChameleonStandardExtension extends \Twig_Extension
         );
     }
 
-    public function getTokenParsers()
-    {
-        return array(
-            new TPkgSnippetRenderer_TranslationTokenParser(),
-        );
-    }
-
     /**
      * chameleonTwigEscapeFilter wraps the original twig escape extension to make sure the authenticity token string
      * won't get escaped by Twig and thus be rendered useless.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#190
| License       | MIT

The problem comes from the upgrade of Twig to 2.x; there are incompatibilites which lead to breaks.
I think we no longer need our custom translation extensions, as we use the default Symfony translation mechanism since Chameleon 6.1.0. Translation of legacy placeholders in "[{ variable }]" isn't supported since that version, either.

Let me know if I'm wrong on some point here @bestform.

// cc @UlrichKu 