### PR TITLE
ref #235: Set English name for tree root

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1544528874.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1544528874.inc.php
@@ -1,0 +1,16 @@
+<h1>Build #1544528874</h1>
+<h2>Date: 2018-12-11</h2>
+<div class="changelog">
+    - Set English name for tree root.
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_tree', 'en')
+    ->setFields([
+        'name' => 'Websites',
+    ])
+    ->setWhereEquals([
+        'id' => '99', // ID can be hard-coded, because we rely on this ID anyway in CMSTreeNodeSelect.
+        'name' => '',
+    ]);
+TCMSLogChange::update(__LINE__, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#235
| License       | MIT

The error was caused in \CMSTreeNodeSelect::RenderTree(). Here we abort if the node's name is empty, which was the case for the English root node.