### PR TITLE
ref #237: Add missing translation field

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1544598819.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1544598819.inc.php
@@ -1,0 +1,11 @@
+<h1>Build #1544598819</h1>
+<h2>Date: 2018-12-12</h2>
+<div class="changelog">
+    - #237: Add missing translation field
+</div>
+<?php
+
+TCMSLogChange::RunQuery(__LINE__, "ALTER TABLE `pkg_cms_credit_check` 
+ADD COLUMN `text_credit_check_pending__de` LONGTEXT NOT NULL AFTER `text_credit_check_pending`");
+
+//  COMMENT 'Hinweistext: Text der angezeigt wird wenn eine Bonitätsüberprüfung durchgeführt wird.\n\nEs stehen folgende Parameter zur Verfügung:\n\n[{firstName}] - Vorname\n[{lastName}] - Nachname\n[{company}] - Firma\n[{street}] - Strasse + Hausnummer\n[{streetName}] -'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#237
| License       | MIT

Adds missing field.

It is however unknown where this problem comes from and why this hasn't been a problem before.