### PR TITLE
ref #238: Restore document selection mechanism

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -178,6 +178,10 @@ function _SetDocumentResponse(data, responseMessage) {
  * sets the choosen document in a TCMSFieldDocument
  */
 function _SetDocument(documentID) {
+    var _currentFieldName = getCMSRegistryEntry('_currentFieldName');
+    var form = document.getElementById('cmseditform');
+    form.querySelector('[name=' + _currentFieldName + ']').value = documentID;
+
     var url = window.location.pathname + "?pagedef=CMSUniversalUploader&module_fnc[contentmodule]=ExecuteAjaxCall&_fnc=GetDownloadHTML&documentID=" + documentID;
     GetAjaxCall(url, _SetDocumentResponse);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#238
| License       | MIT

This functionality was destroyed by zealous cleanup work in 6.2.0.