### PR TITLE
Fix/Translated Fields Class Lookup

### DIFF
--- a/src/CoreBundle/Field/Provider/ClassFromTableFieldProvider.php
+++ b/src/CoreBundle/Field/Provider/ClassFromTableFieldProvider.php
@@ -33,8 +33,10 @@ class ClassFromTableFieldProvider implements ClassFromTableFieldProviderInterfac
         if ('id' === $tableField) {
             return null;
         }
+
         $tableFieldDictionary = $this->getDictionaryFromTableField($tableField);
         $fieldName = $tableFieldDictionary['fieldName'];
+
         if ('id' === $fieldName || 'cmsident' === $fieldName) {
             return null;
         }
@@ -64,9 +66,12 @@ class ClassFromTableFieldProvider implements ClassFromTableFieldProviderInterfac
             return null;
         }
 
+        $tableName = $tableConfIdSplit[0];
+        $fieldName = $this->stripFieldTranslationSuffix($tableConfIdSplit[1]);
+
         return array(
-            'tableName' => $tableConfIdSplit[0],
-            'fieldName' => $tableConfIdSplit[1],
+            'tableName' => $tableName,
+            'fieldName' => $fieldName,
         );
     }
 

--- a/src/CoreBundle/Field/Provider/ClassFromTableFieldProvider.php
+++ b/src/CoreBundle/Field/Provider/ClassFromTableFieldProvider.php
@@ -69,4 +69,14 @@ class ClassFromTableFieldProvider implements ClassFromTableFieldProviderInterfac
             'fieldName' => $tableConfIdSplit[1],
         );
     }
+
+    /**
+     * @param string $suffixedFieldName
+     *
+     * @return string
+     */
+    private function stripFieldTranslationSuffix(string $suffixedFieldName): string
+    {
+        return preg_replace('/__\w+$/', '', $suffixedFieldName);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#241
| License       | MIT

Remove translation suffix for fields when looking up a responsible field class through provider. Translation suffix will never make a difference in the field class used, making this a safe operation, effectively converting each lookup of a translated field (by name) to a lookup of the corresponding untranslated field.