### PR TITLE
ref #242: add missing leading slash in relativeSourceUrl to non exact…

### DIFF
--- a/src/UrlAliasBundle/objects/TCMSSmartURLHandler/TCMSSmartURLHandler_URLAlias.class.php
+++ b/src/UrlAliasBundle/objects/TCMSSmartURLHandler/TCMSSmartURLHandler_URLAlias.class.php
@@ -141,7 +141,7 @@ class TCMSSmartURLHandler_URLAlias extends TCMSSmartURLHandler
         }
 
         // handle non exact match records
-        $conditions[] = sprintf("(`exact_match` = '0' AND `source_url` LIKE %s)", $dbConnection->quote($relativeSourceUrl.'%'));
+        $conditions[] = sprintf("(`exact_match` = '0' AND `source_url` LIKE %s)", $dbConnection->quote('/'.$relativeSourceUrl.'%'));
         $conditions[] = sprintf("(`exact_match` = '0' AND `source_url` LIKE %s)", $dbConnection->quote($absoluteSourceUrl.'%'));
 
         /** @var $oPortal TdbCmsPortal */


### PR DESCRIPTION
… match query condition

Restores the behaviour for non exact match redirects before chameleon-system/chameleon-system#82

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#242
| License       | MIT

