### PR TITLE
230 avoid overwrites in postsavehook

### DIFF
--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -150,7 +150,7 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
     /**
      * computes differences between new and old values.
      *
-     * @param TIterator  $newFields    holds an iterator of all field classes from DB table with the posted values or default if no post data is present
+     * @param TIterator  $newFields  holds an iterator of all field classes from DB table with the posted values or default if no post data is present
      * @param TCMSRecord $oPostTable holds the record object of all posted data
      *
      * @return array

--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -325,7 +325,6 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
         if ($this->oTableConf->fieldChangelogActive) {
             $this->failOnForbiddenTables();
 
-            // TODO? this still overwrites the value from Save() above - if executed in the PostSaveHook() of a sub class TableEditor
             if (null !== $this->sId) {
                 $this->bIsUpdate = true;
             } else {

--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -64,11 +64,7 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
         if ($this->oTableConf->fieldChangelogActive) {
             $this->failOnForbiddenTables();
 
-            if (isset($postData['id'])) {
-                $this->bIsUpdate = true;
-            } else {
-                $this->bIsUpdate = false;
-            }
+            $this->bIsUpdate = isset($postData['id']);
         }
 
         return parent::Save($postData, $bDataIsInSQLForm);
@@ -325,11 +321,7 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
         if ($this->oTableConf->fieldChangelogActive) {
             $this->failOnForbiddenTables();
 
-            if (null !== $this->sId) {
-                $this->bIsUpdate = true;
-            } else {
-                $this->bIsUpdate = false;
-            }
+            $this->bIsUpdate = null !== $this->sId;
         }
 
         return parent::SaveField(

--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -20,8 +20,6 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
      * the original data of the row before a save overwrites the data.
      *
      * @var TCMSField[]
-     *
-     * @deprecated since 6.3.0 - determined from $this->oTablePreChangeData
      */
     protected $oOldFields = array();
 
@@ -77,9 +75,9 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
     }
 
     /**
-     * @param array $postData
+     * Not used anymore. Handled with $this->oTablePreChangeData.
      *
-     * @deprecated since 6.3.0 - the existing $this->oTablePreChangeData is used
+     * @param array $postData
      */
     protected function savePreSaveValues(array $postData)
     {

--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -153,7 +153,7 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
      *
      * @return array
      */
-    protected function computeDifferences($newFields, $oPostTable)
+    protected function computeDifferences(&$newFields, &$oPostTable)
     {
         $result = [];
 

--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -20,8 +20,11 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
      * the original data of the row before a save overwrites the data.
      *
      * @var TCMSField[]
+     *
+     * @deprecated since 6.3.0 - determined from $this->oTablePreChangeData
      */
     protected $oOldFields = array();
+
     /**
      * @var bool
      */
@@ -62,7 +65,12 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
     {
         if ($this->oTableConf->fieldChangelogActive) {
             $this->failOnForbiddenTables();
-            $this->savePreSaveValues($postData);
+
+            if (isset($postData['id'])) {
+                $this->bIsUpdate = true;
+            } else {
+                $this->bIsUpdate = false;
+            }
         }
 
         return parent::Save($postData, $bDataIsInSQLForm);
@@ -70,6 +78,8 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
 
     /**
      * @param array $postData
+     *
+     * @deprecated since 6.3.0 - the existing $this->oTablePreChangeData is used
      */
     protected function savePreSaveValues(array $postData)
     {
@@ -140,56 +150,58 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
     /**
      * computes differences between new and old values.
      *
-     * @param TIterator  $oFields    holds an iterator of all field classes from DB table with the posted values or default if no post data is present
+     * @param TIterator  $newFields    holds an iterator of all field classes from DB table with the posted values or default if no post data is present
      * @param TCMSRecord $oPostTable holds the record object of all posted data
      *
      * @return array
      */
-    protected function computeDifferences(&$oFields, &$oPostTable)
+    protected function computeDifferences($newFields, $oPostTable)
     {
-        $aRetValue = array();
+        $result = [];
 
-        $oFields->GoToStart();
-        /** @var TCMSField $oField */
-        while ($oField = $oFields->Next()) {
-            /** @var TCMSField $oOldField */
-            if (isset($this->oOldFields[$oField->name])) {
-                $oOldField = $this->oOldFields[$oField->name];
+        $oldFields = $this->getOldFields();
+
+        $newFields->GoToStart();
+        /** @var TCMSField $newField */
+        while ($newField = $newFields->next()) {
+            /** @var TCMSField $oldField */
+            if (isset($oldFields[$newField->name])) {
+                $oldField = $oldFields[$newField->name];
             } else {
                 if ($this->bIsUpdate) {
                     continue;
                 }
-                $oOldField = clone $oField;
-                $oOldField->data = $oOldField->oDefinition->fieldFieldDefaultValue;
+                $oldField = clone $newField;
+                $oldField->data = $oldField->oDefinition->fieldFieldDefaultValue;
             }
 
-            $oField = clone $oField;
-            $oField->data = $oField->ConvertPostDataToSQL();
+            $newField = clone $newField;
+            $newField->data = $newField->ConvertPostDataToSQL();
 
-            if (is_array($oOldField->data)) {
-                if (isset($oOldField->data['x']) && '-' === $oOldField->data['x']) {
-                    unset($oOldField->data['x']);
+            if (is_array($oldField->data)) {
+                if (isset($oldField->data['x']) && '-' === $oldField->data['x']) {
+                    unset($oldField->data['x']);
                 }
             }
-            if (is_array($oField->data)) {
-                if (isset($oField->data['x']) && '-' === $oField->data['x']) {
-                    unset($oField->data['x']);
+            if (is_array($newField->data)) {
+                if (isset($newField->data['x']) && '-' === $newField->data['x']) {
+                    unset($newField->data['x']);
                 }
             }
 
-            $oEqualsVisitor = new TCMSFieldEqualsVisitor($oOldField, $oField);
-            $bIsEqual = $oEqualsVisitor->check();
-            if (!$bIsEqual) {
-                $sFieldId = $oField->oDefinition->id;
-                if ($oField->getBEncryptedData()) {
-                    $aRetValue[] = array($sFieldId, '', '');
+            $equalsVisitor = new TCMSFieldEqualsVisitor($oldField, $newField);
+            $isEqual = $equalsVisitor->check();
+            if (!$isEqual) {
+                $fieldId = $newField->oDefinition->id;
+                if ($newField->getBEncryptedData()) {
+                    $result[] = array($fieldId, '', '');
                 } else {
-                    $aRetValue[] = array($sFieldId, $oOldField->data, $oField->data);
+                    $result[] = array($fieldId, $oldField->data, $newField->data);
                 }
             }
         }
 
-        return $aRetValue;
+        return $result;
     }
 
     /**
@@ -314,7 +326,13 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
     {
         if ($this->oTableConf->fieldChangelogActive) {
             $this->failOnForbiddenTables();
-            $this->savePreSaveValues(array($sFieldName => $sFieldContent, 'id' => $this->sId));
+
+            // TODO? this still overwrites the value from Save() above - if executed in the PostSaveHook() of a sub class TableEditor
+            if (null !== $this->sId) {
+                $this->bIsUpdate = true;
+            } else {
+                $this->bIsUpdate = false;
+            }
         }
 
         return parent::SaveField(
@@ -357,6 +375,14 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
             /** @var TCMSField $oField */
             $this->createChangeItems($sChangeSetId, array($change));
         }
+    }
+
+    /**
+     * @return array
+     */
+    private function getOldFields(): array
+    {
+        return $this->oTablePreChangeData->getFields();
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPage.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPage.class.php
@@ -64,13 +64,8 @@ class TCMSTableEditorPage extends TCMSTableEditor
      */
     protected function PostSaveHook(&$oFields, &$oPostTable)
     {
-        parent::PostSaveHook($oFields, $oPostTable);
-
         $this->UpdatePageNaviBreadCrumb();
-        // TODO With this reversed order this save cannot be part of the change log...
-        // But otherwise this second save overwrites the (new) values of the first general save
-
-        // Also note vendor/chameleon-system/chameleon-base/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php:100
+        parent::PostSaveHook($oFields, $oPostTable);
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPage.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPage.class.php
@@ -64,8 +64,13 @@ class TCMSTableEditorPage extends TCMSTableEditor
      */
     protected function PostSaveHook(&$oFields, &$oPostTable)
     {
-        $this->UpdatePageNaviBreadCrumb();
         parent::PostSaveHook($oFields, $oPostTable);
+
+        $this->UpdatePageNaviBreadCrumb();
+        // TODO With this reversed order this save cannot be part of the change log...
+        // But otherwise this second save overwrites the (new) values of the first general save
+
+        // Also note vendor/chameleon-system/chameleon-base/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php:100
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
@@ -890,6 +890,24 @@ class TCMSRecord implements IPkgCmsSessionPostWakeupListener
     }
 
     /**
+     * @return array - the fields with current values; indexed by field name
+     */
+    public function getFields(): array
+    {
+        $fieldsIterator = $this->GetTableConf()->GetFields($this);
+
+        $fields = [];
+        /**
+         * @var TCMSField $field
+         */
+        while ($field = $fieldsIterator->next()) {
+            $fields[$field->name] = $field;
+        }
+
+        return $fields;
+    }
+
+    /**
      * returns iterator of images.
      *
      * @param string $fieldName


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#230
| License       | MIT

Uses an existing variable with the "old data". That is not overwritten.