### PR TITLE
228 compare correct old field values

### DIFF
--- a/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
+++ b/src/CmsChangeLogBundle/src/esono/pkgcmschangelog/TCMSTableEditor/TCMSTableEditorChangeLog.class.php
@@ -170,7 +170,11 @@ class TCMSTableEditorChangeLog extends TCMSTableEditorChangeLogAutoParent
             }
 
             $newField = clone $newField;
-            $newField->data = $newField->ConvertPostDataToSQL();
+            if ($newField instanceof TCMSMLTField) {
+                $newField->data = $newField->getMltValues();
+            } else {
+                $newField->data = $newField->ConvertPostDataToSQL();
+            }
 
             if (is_array($oldField->data)) {
                 if (isset($oldField->data['x']) && '-' === $oldField->data['x']) {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSFieldDefinition.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSFieldDefinition.class.php
@@ -571,7 +571,7 @@ class TCMSFieldDefinition extends TCMSRecord
 
     public function isTranslatable(): bool
     {
-        return '!' === $this->sqlData['is_translatable'];
+        return '1' === $this->sqlData['is_translatable'];
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSFieldDefinition.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSFieldDefinition.class.php
@@ -569,6 +569,11 @@ class TCMSFieldDefinition extends TCMSRecord
         return $tableName;
     }
 
+    public function isTranslatable(): bool
+    {
+        return '!' === $this->sqlData['is_translatable'];
+    }
+
     /**
      * returns the field name - respects the current language setting.
      *
@@ -580,9 +585,10 @@ class TCMSFieldDefinition extends TCMSRecord
     {
         $sTargetFieldName = $this->sqlData['name'];
 
-        if ('0' === $this->sqlData['is_translatable']) {
+        if (false === $this->isTranslatable()) {
             return $sTargetFieldName;
         }
+
         $language = null;
         if (null === $sLanguageID) {
             $oUser = &TCMSUser::GetActiveUser();
@@ -612,9 +618,10 @@ class TCMSFieldDefinition extends TCMSRecord
      */
     public function GetEditFieldNameForLanguage($oLanguage)
     {
-        if ('0' === $this->sqlData['is_translatable']) {
+        if (false === $this->isTranslatable()) {
             return false;
         }
+
         if (TdbCmsConfig::GetInstance()->fieldTranslationBaseLanguageId === $oLanguage->id) {
             return $this->sqlData['name'];
         } else {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -154,8 +154,6 @@ class TCMSTableConf extends TCMSRecord
      */
     public function &GetFields(&$oTableRow, $loadDefaults = false, $bDoNotUseAutoObjects = false)
     {
-        $languageService = self::getLanguageService();
-
         $oFieldDefinition = &$this->GetFieldDefinitions(array(), $bDoNotUseAutoObjects);
         $oFields = new TIterator();
         while ($oFieldDef = $oFieldDefinition->next()) {
@@ -193,7 +191,7 @@ class TCMSTableConf extends TCMSRecord
                         // Standard case
                         // Try to find the correct field name for the data in $oTableRow with respect to the language
 
-                        $data = $this->getDataForCurrentLanguage($oFieldDef, $oTableRow->sqlData, $languageService);
+                        $data = $this->getDataForCurrentLanguage($oFieldDef, $oTableRow->sqlData);
 
                         if (null === $data) {
                             $data = $oTableRow->sqlData[$oField->name];
@@ -216,11 +214,10 @@ class TCMSTableConf extends TCMSRecord
     /**
      * @param TdbCmsFieldConf|TCMSFieldDefinition $fieldDefinition
      * @param array                               $sqlData
-     * @param LanguageServiceInterface            $languageService
      *
      * @return mixed
      */
-    private function getDataForCurrentLanguage($fieldDefinition, array $sqlData, LanguageServiceInterface $languageService)
+    private function getDataForCurrentLanguage($fieldDefinition, array $sqlData)
     {
         $languageId = $this->GetLanguage();
 
@@ -228,7 +225,7 @@ class TCMSTableConf extends TCMSRecord
             return null;
         }
 
-        $language = $languageService->getLanguage($languageId);
+        $language = self::getLanguageService()->getLanguage($languageId);
 
         if (null === $language) {
             return null;

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -155,7 +155,6 @@ class TCMSTableConf extends TCMSRecord
     public function &GetFields(&$oTableRow, $loadDefaults = false, $bDoNotUseAutoObjects = false)
     {
         $languageService = self::getLanguageService();
-        $currentLanguage = $languageService->getLanguage($this->GetLanguage());
 
         $oFieldDefinition = &$this->GetFieldDefinitions(array(), $bDoNotUseAutoObjects);
         $oFields = new TIterator();

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -190,15 +190,17 @@ class TCMSTableConf extends TCMSRecord
                     if (array_key_exists($oField->name.'-original', $oTableRow->sqlData)) {
                         $oField->data = $oTableRow->sqlData[$oField->name.'-original'];
                     } else {
+                        // Standard case
+                        // Try to find the correct field name for the data in $oTableRow with respect to the language
+
                         $fieldName = $oField->name;
 
                         if ($language !== null) {
-                            $fieldName = $oFieldDef->GetEditFieldNameForLanguage($language);
-                        }
+                            $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($language);
 
-                        if (false === \array_key_exists($fieldName, $oTableRow->sqlData)) {
-                            // Could be a Save() - containing only mono-language data
-                            $fieldName = $oField->name;
+                            if (true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {
+                                $fieldName = $fieldNameForLanguage;
+                            } // else could be a Save() - containing only mono-language data
                         }
 
                         $oField->data = $oTableRow->sqlData[$fieldName];

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -152,7 +152,6 @@ class TCMSTableConf extends TCMSRecord
      */
     public function &GetFields(&$oTableRow, $loadDefaults = false, $bDoNotUseAutoObjects = false)
     {
-        // TODO this could also be a parameter here?
         $languageService = self::getLanguageService();
         $language = $languageService->getActiveEditLanguage();
 

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -152,6 +152,7 @@ class TCMSTableConf extends TCMSRecord
      */
     public function &GetFields(&$oTableRow, $loadDefaults = false, $bDoNotUseAutoObjects = false)
     {
+        // TODO this could also be a parameter here?
         $languageService = self::getLanguageService();
         $language = $languageService->getActiveEditLanguage();
 

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -196,6 +196,7 @@ class TCMSTableConf extends TCMSRecord
                         $fieldName = $oField->name;
 
                         if ($language !== null) {
+                            // TODO GetEditFieldNameForLanguage() returns wrong if the base translation language === current language
                             $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($language);
 
                             if (false !== $fieldNameForLanguage && true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -152,9 +152,6 @@ class TCMSTableConf extends TCMSRecord
      */
     public function &GetFields(&$oTableRow, $loadDefaults = false, $bDoNotUseAutoObjects = false)
     {
-        $languageService = self::getLanguageService();
-        $language = $languageService->getActiveEditLanguage();
-
         $oFieldDefinition = &$this->GetFieldDefinitions(array(), $bDoNotUseAutoObjects);
         $oFields = new TIterator();
         while ($oFieldDef = $oFieldDefinition->next()) {
@@ -194,8 +191,11 @@ class TCMSTableConf extends TCMSRecord
 
                         $fieldName = $oField->name;
 
-                        if ($language !== null) {
-                            $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($language);
+                        $languageService = self::getLanguageService();
+                        $currentLanguage = $languageService->getLanguage($this->GetLanguage());
+
+                        if ($currentLanguage !== null) {
+                            $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($currentLanguage);
 
                             if (false !== $fieldNameForLanguage && true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {
                                 $fieldName = $fieldNameForLanguage;

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -217,7 +217,7 @@ class TCMSTableConf extends TCMSRecord
      * @param TdbCmsFieldConf|TCMSFieldDefinition $fieldDefinition
      * @param array                               $sqlData
      * @param LanguageServiceInterface            $languageService
-     * @return mixed|null
+     * @return mixed
      */
     private function getDataForCurrentLanguage($fieldDefinition, array $sqlData, LanguageServiceInterface $languageService)
     {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -258,7 +258,16 @@ class TCMSTableConf extends TCMSRecord
             if ($loadDefaults) {
                 $oField->data = $oFieldDef->sqlData['field_default_value'];
             } elseif (null !== $oTableRow && is_array($oTableRow->sqlData) && array_key_exists($oField->name, $oTableRow->sqlData)) {
-                $oField->data = $oTableRow->sqlData[$oField->name];
+                $languageService = self::getLanguageService();
+                $currentLanguage = $languageService->getLanguage($this->GetLanguage());
+
+                $data = $this->getDataForLanguage($oFieldDef, $oTableRow->sqlData, $currentLanguage);
+
+                if (null === $data) {
+                    $data = $oTableRow->sqlData[$oField->name];
+                }
+
+                $oField->data = $data;
             }
             $oField->oDefinition = $oFieldDef;
             $oField->oTableRow = $oTableRow;

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -198,7 +198,7 @@ class TCMSTableConf extends TCMSRecord
                         if ($language !== null) {
                             $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($language);
 
-                            if (true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {
+                            if (false !== $fieldNameForLanguage && true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {
                                 $fieldName = $fieldNameForLanguage;
                             } // else could be a Save() - containing only mono-language data
                         }

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -195,7 +195,6 @@ class TCMSTableConf extends TCMSRecord
                         $fieldName = $oField->name;
 
                         if ($language !== null) {
-                            // TODO GetEditFieldNameForLanguage() returns wrong if the base translation language === current language
                             $fieldNameForLanguage = $oFieldDef->GetEditFieldNameForLanguage($language);
 
                             if (false !== $fieldNameForLanguage && true === \array_key_exists($fieldNameForLanguage, $oTableRow->sqlData)) {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -217,6 +217,7 @@ class TCMSTableConf extends TCMSRecord
      * @param TdbCmsFieldConf|TCMSFieldDefinition $fieldDefinition
      * @param array                               $sqlData
      * @param LanguageServiceInterface            $languageService
+     *
      * @return mixed
      */
     private function getDataForCurrentLanguage($fieldDefinition, array $sqlData, LanguageServiceInterface $languageService)
@@ -229,7 +230,7 @@ class TCMSTableConf extends TCMSRecord
 
         $language = $languageService->getLanguage($languageId);
 
-        if ($language === null) {
+        if (null === $language) {
             return null;
         }
 

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTableConf.class.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
+
 /**
  * the Table metadata manager.
  * db table: cms_tbl_conf.
@@ -192,7 +194,7 @@ class TCMSTableConf extends TCMSRecord
                         // Standard case
                         // Try to find the correct field name for the data in $oTableRow with respect to the language
 
-                        $data = $this->getDataForLanguage($oFieldDef, $oTableRow->sqlData, $currentLanguage);
+                        $data = $this->getDataForCurrentLanguage($oFieldDef, $oTableRow->sqlData, $languageService);
 
                         if (null === $data) {
                             $data = $oTableRow->sqlData[$oField->name];
@@ -215,11 +217,19 @@ class TCMSTableConf extends TCMSRecord
     /**
      * @param TdbCmsFieldConf|TCMSFieldDefinition $fieldDefinition
      * @param array                               $sqlData
-     * @param null|TdbCmsLanguage                 $language
+     * @param LanguageServiceInterface            $languageService
      * @return mixed|null
      */
-    private function getDataForLanguage($fieldDefinition, array $sqlData, ?TdbCmsLanguage $language)
+    private function getDataForCurrentLanguage($fieldDefinition, array $sqlData, LanguageServiceInterface $languageService)
     {
+        $languageId = $this->GetLanguage();
+
+        if (null === $languageId) {
+            return null;
+        }
+
+        $language = $languageService->getLanguage($languageId);
+
         if ($language === null) {
             return null;
         }
@@ -259,9 +269,8 @@ class TCMSTableConf extends TCMSRecord
                 $oField->data = $oFieldDef->sqlData['field_default_value'];
             } elseif (null !== $oTableRow && is_array($oTableRow->sqlData) && array_key_exists($oField->name, $oTableRow->sqlData)) {
                 $languageService = self::getLanguageService();
-                $currentLanguage = $languageService->getLanguage($this->GetLanguage());
 
-                $data = $this->getDataForLanguage($oFieldDef, $oTableRow->sqlData, $currentLanguage);
+                $data = $this->getDataForCurrentLanguage($oFieldDef, $oTableRow->sqlData, $languageService);
 
                 if (null === $data) {
                     $data = $oTableRow->sqlData[$oField->name];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#228
| License       | MIT

Done: Determine MLT (compare) values correctly. Consider language during field load/comparisson.
This not yet finished (see Todos).