### PR TITLE
ref #279: Make sure oTablePreChangeData is set before calling PostSaveHook()

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -937,6 +937,10 @@ class TCMSTableEditorEndPoint
      */
     public function SaveField($sFieldName, $sFieldContent, $bTriggerPostSaveHook = false)
     {
+        if (!is_null($this->oTable)) {
+            $this->oTablePreChangeData = clone $this->oTable;
+        }
+
         $oPostTable = $this->GetNewTableObjectForEditor();
         $postData = array($sFieldName => $sFieldContent, 'id' => $this->sId);
         $oPostTable->DisablePostLoadHook(true);
@@ -974,6 +978,10 @@ class TCMSTableEditorEndPoint
      */
     public function SaveFields($aFieldData, $bTriggerPostSaveHook = false)
     {
+        if (!is_null($this->oTable)) {
+            $this->oTablePreChangeData = clone $this->oTable;
+        }
+
         $oPostTable = $this->GetNewTableObjectForEditor();
         $postData = $aFieldData;
         $postData['id'] = $this->sId;
@@ -2880,6 +2888,10 @@ class TCMSTableEditorEndPoint
      */
     protected function ActivateRecordRevision_Execute($oCMSRevisionToActivate)
     {
+        if (!is_null($this->oTable)) {
+            $this->oTablePreChangeData = clone $this->oTable;
+        }
+
         $aRevisionPostData = TTools::mb_safe_unserialize($oCMSRevisionToActivate->fieldData);
         $oDBRecordTable = $this->oTableConf->GetTableObjectInstance();
         $aRevisionPostData['id'] = $oCMSRevisionToActivate->fieldRecordid;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#279
| License       | MIT
