### PR TITLE
WIP ref #100: Add sidebar menu

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -142,6 +142,19 @@ monolog:
        level: warning
 ```
 
+## Backend Pagedef Configuration
+
+The backend now provides a new sidebar menu which will replace the classic main menu in a future version.
+If your project uses custom pagedef files (`*.pagedef.php`), consider adding the sidebar to these files. This is
+done by adding the following line after the module list definition:
+
+```php
+    addDefaultSidebar($moduleList);
+```
+
+There are additional helper methods to simplify adding typical backend modules, but it is optional to use these methods.
+See `src/CoreBundle/private/library/classes/pagedefFunctions.php` for reference.
+
 ## Mailer Peer Security
 
 The default value of config key `chameleon_system_core: mailer: peer_security` was changed from "permissive" to "strict".
@@ -275,6 +288,9 @@ is recommended (although this tool may not find database-related deprecations).
 ## Classes and Interfaces
 
 - \IPkgCmsCoreLog
+- \TCMSMenuItem
+- \TCMSMenuItem_Module
+- \TCMSMenuItem_Table
 - \TPkgCmsCoreLog
 
 ## Properties
@@ -367,7 +383,7 @@ None.
 
 ## Database Fields
 
-None.
+- cms_module.show_as_popup
 
 ## Backend Theme Library
 

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1548168211.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1548168211.inc.php
@@ -1,0 +1,38 @@
+<h1>Build #1548168211</h1>
+<h2>Date: 2019-01-22</h2>
+<div class="changelog">
+    - Add sidebar backend module.
+</div>
+<?php
+
+$moduleId = TCMSLogChange::createUnusedRecordId('cms_tpl_module');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_tpl_module', 'en')
+  ->setFields([
+      'description' => 'This module provides the backend sidebar menu.',
+      'icon_list' => 'application.png',
+      'view_mapper_config' => 'standard=BackendSidebar/standard.html.twig',
+      'mapper_chain' => '',
+      'view_mapping' => '',
+      'revision_management_active' => '0',
+      'is_copy_allowed' => '0',
+      'show_in_template_engine' => '0',
+      'position' => '',
+      'is_restricted' => '0',
+      'name' => 'Sidebar backend module',
+      'classname' => 'chameleon_system_core.module.sidebar.sidebar_backend_module',
+      'id' => $moduleId,
+  ])
+;
+TCMSLogChange::insert(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_tpl_module', 'de')
+  ->setFields([
+      'description' => 'Dieses Modul stellt das Seitenmenü im Backend bereit.',
+      'name' => 'Seitenmenü Backendmodul',
+  ])
+  ->setWhereEquals([
+      'id' => $moduleId,
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1548315858.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1548315858.inc.php
@@ -1,0 +1,28 @@
+<h1>Build #1548315858</h1>
+<h2>Date: 2019-01-24</h2>
+<div class="changelog">
+    - Mark cms_module.show_as_popup as deprecated.
+</div>
+<?php
+
+$fieldId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('cms_module'), 'show_as_popup');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+    ->setFields([
+        '049_helptext' => '@deprecated since 6.3.0 - no longer used',
+    ])
+    ->setWhereEquals([
+        'id' => $fieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+  ->setFields([
+      '049_helptext' => '@deprecated since 6.3.0 - no longer used',
+  ])
+  ->setWhereEquals([
+      'id' => $fieldId,
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\Sidebar;
+
+class MenuCategory
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var array
+     */
+    private $menuItems;
+
+    public function __construct(string $name, array $menuItems)
+    {
+        $this->name = $name;
+        $this->menuItems = $menuItems;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getMenuItems(): array
+    {
+        return $this->menuItems;
+    }
+}

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuItem.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuItem.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\Sidebar;
+
+class MenuItem
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var string
+     */
+    private $icon;
+    /**
+     * @var string
+     */
+    private $url;
+
+    public function __construct(string $name, string $icon, string $url)
+    {
+        $this->name = $name;
+        $this->icon = $icon;
+        $this->url = $url;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\Sidebar;
+
+use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
+
+class SidebarBackendModule extends \MTPkgViewRendererAbstractModuleMapper
+{
+    /**
+     * @var LanguageServiceInterface
+     */
+    private $languageService;
+
+    public function __construct(LanguageServiceInterface $languageService)
+    {
+        parent::__construct();
+        $this->languageService = $languageService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function Accept(\IMapperVisitorRestricted $oVisitor, $bCachingEnabled, \IMapperCacheTriggerRestricted $oCacheTriggerManager)
+    {
+        $oVisitor->SetMappedValue('menuItems', $this->getMenuItems());
+    }
+
+    private function getMenuItems(): array
+    {
+        $activeLanguageId = $this->languageService->getActiveLanguageId();
+        $activeUser = \TCMSUser::GetActiveUser();
+        if (null === $activeUser) {
+            return [];
+        }
+
+        $menuItemsRaw = [];
+        $this->addTableMenuItems($menuItemsRaw, $activeUser, $activeLanguageId);
+        $this->addModuleMenuItems($menuItemsRaw, $activeUser, $activeLanguageId);
+
+        return $this->mergeMenuItems($menuItemsRaw);
+    }
+
+    private function addTableMenuItems(array &$aMenuItemsTemp, \TCMSUser $activeUser, string $activeLanguageId): void
+    {
+        $query = "SELECT * FROM `cms_tbl_conf` WHERE `cms_content_box_id` <> '' AND `cms_content_box_id` <> '0'";
+        $tableList = \TdbCmsTblConfList::GetList($query, $activeLanguageId);
+        while ($tableObject = $tableList->Next()) {
+            if (false === $this->isTableAccessAllowed($activeUser, $tableObject)) {
+                continue;
+            }
+            if (false === \array_key_exists($tableObject->fieldCmsContentBoxId, $aMenuItemsTemp)) {
+                $aMenuItemsTemp[$tableObject->fieldCmsContentBoxId] = [];
+            }
+            $aMenuItemsTemp[$tableObject->fieldCmsContentBoxId][] = new MenuItem(
+                $tableObject->fieldTranslation,
+                $tableObject->fieldIconList,
+                $this->getTableTargetUrl($tableObject->id)
+            );
+        }
+    }
+
+    private function isTableAccessAllowed(\TCMSUser $activeUser, \TdbCmsTblConf $tableObject): bool
+    {
+        $tableInUserGroup = $activeUser->oAccessManager->user->IsInGroups($tableObject->fieldCmsUsergroupId);
+        $isEditAllowed = $activeUser->oAccessManager->HasEditPermission($tableObject->fieldName);
+        $isShowAllReadonlyAllowed = $activeUser->oAccessManager->HasShowAllReadOnlyPermission($tableObject->fieldName);
+
+        return (true === $tableInUserGroup && (true === $isEditAllowed || true === $isShowAllReadonlyAllowed));
+    }
+
+    private function getTableTargetUrl(string $tableId): string
+    {
+        return PATH_CMS_CONTROLLER."?pagedef=tablemanager&id=$tableId";
+    }
+
+    private function addModuleMenuItems(array &$menuItemsRaw, \TCMSUser $activeUser, string $activeLanguageId): void
+    {
+        $query = "SELECT * FROM `cms_module` WHERE `active` = '1'";
+        $cmsModuleList = \TdbCmsModuleList::GetList($query, $activeLanguageId);
+        while ($cmsModule = $cmsModuleList->Next()) {
+            if (false === $this->isModuleAccessAllowed($activeUser, $cmsModule)) {
+                continue;
+            }
+            if (false === \array_key_exists($cmsModule->fieldCmsContentBoxId, $menuItemsRaw)) {
+                $menuItemsRaw[$cmsModule->fieldCmsContentBoxId] = [];
+            }
+            $menuItemsRaw[$cmsModule->fieldCmsContentBoxId][] = new MenuItem(
+                $cmsModule->fieldName,
+                $cmsModule->fieldIconList,
+                $this->getModuleTargetUrl($cmsModule)
+            );
+        }
+    }
+
+    private function isModuleAccessAllowed(\TCMSUser $activeUser, \TdbCmsModule $cmsModule): bool
+    {
+        return true === $activeUser->oAccessManager->user->IsInGroups($cmsModule->fieldCmsUsergroupId);
+    }
+
+    private function getModuleTargetUrl(\TdbCmsModule $cmsModule): string
+    {
+        $url = PATH_CMS_CONTROLLER.'?pagedef='.$cmsModule->fieldModule;
+        if ('' !== $cmsModule->fieldParameter) {
+            $url .= '&'.$cmsModule->fieldParameter;
+        }
+        if ('' !== $cmsModule->fieldModuleLocation) {
+            $url .= '&_pagedefType='.$cmsModule->fieldModuleLocation;
+        }
+
+        return $url;
+    }
+
+    private function mergeMenuItems(array $menuItemsRaw): array
+    {
+        $categoryNames = $this->getCategoryNames();
+        $menuItems = [];
+        foreach ($menuItemsRaw as $categoryId => $items) {
+            if (true === \array_key_exists($categoryId, $categoryNames)) {
+                $categoryName = $categoryNames[$categoryId];
+            } else {
+                $categoryName = '-';
+            }
+            \usort($items, function (MenuItem $menuItem1, MenuItem $menuItem2) {
+                return \strcmp($menuItem1->getName(), $menuItem2->getName());
+            });
+            $menuItems[] = new MenuCategory($categoryName, $items);
+        }
+        \usort($menuItems, function (MenuCategory $menuCategory1, MenuCategory $menuCategory2) {
+            return \strcmp($menuCategory1->getName(), $menuCategory2->getName());
+        });
+
+        return $menuItems;
+    }
+
+    private function getCategoryNames(): array
+    {
+        $contentBoxList = \TdbCmsContentBoxList::GetList('SELECT * FROM `cms_content_box`');
+        $names = [];
+        while ($contentBox = $contentBoxList->Next()) {
+            $names[$contentBox->id] = $contentBox->fieldName;
+        }
+
+        return $names;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function GetHtmlFooterIncludes()
+    {
+        $includes = parent::GetHtmlFooterIncludes();
+        $includes[] = sprintf('<script src="%s" type="text/javascript"></script>',
+            \TGlobal::GetStaticURLToWebLib('/javascript/modules/sidebar/sidebar.js'));
+
+        return $includes;
+    }
+}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSCreateSearchIndex.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSCreateSearchIndex.pagedef.php
@@ -4,13 +4,13 @@
  * @deprecated since 6.2.0 - no longer used.
  */
 
-// main layout
 $layoutTemplate = 'popup_window_iframe';
+$moduleList = [
+    'contentmodule' => [
+        'model' => 'CMSSearch',
+        'view' => 'standard',
+        '_suppressHistory' => true,
+    ],
+];
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSSearch', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSCreateSearchIndexPlain.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSCreateSearchIndexPlain.pagedef.php
@@ -4,13 +4,5 @@
  * @deprecated since 6.2.0 - no longer used.
  */
 
-// main layout
 $layoutTemplate = 'empty';
-
-// modules...
 $moduleList = array('main' => array('model' => 'CMSSearch', 'view' => 'index', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentLocalImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentLocalImport.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSDocumentLocalImport', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSDocumentLocalImport', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentManager.pagedef.php
@@ -1,21 +1,11 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'CMSDocumentManager',
         'view' => 'standard',
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentManagerTreeRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentManagerTreeRPC.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSDocumentManagerTreeRPC', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentSelect.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSDocumentSelect.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'CMSModuleDocumentChooser', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSModuleDocumentChooser', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSFieldMLTPosition.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSFieldMLTPosition.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
 $moduleList = array('contentmodule' => array('model' => 'CMSFieldMLTRPC', 'view' => 'sort'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSFieldMLTRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSFieldMLTRPC.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSFieldMLTRPC', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSFieldPositionRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSFieldPositionRPC.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
 $moduleList = array('contentmodule' => array('model' => 'CMSFieldPositionRPC', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSImageManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSImageManager.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSModuleImageManager', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSImageManagerLoadImage.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSImageManagerLoadImage.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'CMSModuleImageManager', 'view' => 'selectimage'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSModuleImageManager', 'view' => 'selectimage'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSMediaLocalImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSMediaLocalImport.pagedef.php
@@ -2,13 +2,7 @@
 /**
  * @deprecated since 6.2.0 - Chameleon has a new media manager
  */
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSMediaLocalImport', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSMediaLocalImport', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManager.pagedef.php
@@ -2,13 +2,7 @@
 /**
  * @deprecated since 6.2.0 - Chameleon has a new media manager
  */
-// main layout
 $layoutTemplate = 'mediaManager';
+$moduleList = array('content' => array('model' => 'CMSMediaManager', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'content' => array('model' => 'CMSMediaManager', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManagerTreeEditNodeRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManagerTreeEditNodeRPC.pagedef.php
@@ -2,13 +2,5 @@
 /**
  * @deprecated since 6.2.0 - Chameleon has a new media manager
  */
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSMediaManagerTreeEditNodeRPC', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManagerTreeRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSMediaManagerTreeRPC.pagedef.php
@@ -2,13 +2,5 @@
 /**
  * @deprecated since 6.2.0 - Chameleon has a new media manager
  */
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSMediaManagerTreeRPC', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSMediaViddlerImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSMediaViddlerImport.pagedef.php
@@ -2,13 +2,7 @@
 /**
  * @deprecated since 6.3.0 - Viddler is no longer supported
  */
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSMediaViddlerImport', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSMediaViddlerImport', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSModuleHelp.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSModuleHelp.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSModuleHelp', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSModuleHelp', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTreeEditNode.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTreeEditNode.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'JSON';
-
-// modules...
 $moduleList = array('module' => array('model' => 'CMSModuleTreeNodeEdit', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTreePlain.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTreePlain.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'ajaxTreePlain';
+$moduleList = array('module' => array('model' => 'CMSModulePageTree', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'module' => array('model' => 'CMSModulePageTree', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSTableExport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSTableExport.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSTableExport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSTableExport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSUniversalUploader.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSUniversalUploader.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSModuleUniversalUploader', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSModuleUniversalUploader', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSUpdateManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSUpdateManager.pagedef.php
@@ -1,15 +1,11 @@
 <?php
 
-// main layout
-$layoutTemplate = 'frame';
+$layoutTemplate = 'default';
+$moduleList = [
+    'contentmodule' => ['model' => 'CMSUpdateManager', 'moduleType' => 'Core', 'view' => 'standard'],
+];
 
-// modules...
-$moduleList = array(
-    'pagetitle' => array('model' => 'MTHeader', 'view' => 'title'),
-    'contentmodule' => array('model' => 'CMSUpdateManager', 'moduleType' => 'Core', 'view' => 'standard'),
-);
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSUserRightsOverview.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSUserRightsOverview.pagedef.php
@@ -1,12 +1,9 @@
 <?php
 
-// main layout
-$layoutTemplate = 'popup_iframe';
+$layoutTemplate = 'default';
+$moduleList = array('contentmodule' => array('model' => 'CMSUserRightsOverview', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'contentmodule' => array('model' => 'CMSUserRightsOverview', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSsmallIconlist.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSsmallIconlist.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSiconList', 'view' => 'standard', 'iconPath' => '/images/icons/'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSiconList', 'view' => 'standard', 'iconPath' => '/images/icons/'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSwysiwygImageChooser.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSwysiwygImageChooser.pagedef.php
@@ -1,21 +1,11 @@
 <?php
 
-// main layout
 $layoutTemplate = 'wysiwygImageChooser';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'content' => array(
+$moduleList = [
+    'content' => [
         'model' => 'CMSModuleWYSIWYGImage',
         'view' => 'standard',
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/CMSwysiwygRPC.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSwysiwygRPC.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'wysiwygImageChooser';
+$moduleList = array('module' => array('model' => 'CMSModuleWYSIWYGImage', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'module' => array('model' => 'CMSModuleWYSIWYGImage', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/NewsletterRobinsonImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/NewsletterRobinsonImport.pagedef.php
@@ -1,12 +1,7 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_window_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSNewsletterRobinsonImport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'moduleType' => 'Core', 'view' => 'standard'), 'contentmodule' => array('model' => 'CMSNewsletterRobinsonImport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/NewsletterSubscriberImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/NewsletterSubscriberImport.pagedef.php
@@ -1,12 +1,7 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_window_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSNewsletterSubscriberImport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'moduleType' => 'Core', 'view' => 'standard'), 'contentmodule' => array('model' => 'CMSNewsletterSubscriberImport', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/api.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/api.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'empty';
-
-// modules...
 $moduleList = array('main' => array('model' => 'MTChameleonApi', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/blogImport.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/blogImport.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
 $moduleList = array('contentmodule' => array('model' => 'MTBlogImportCore', 'moduleType' => 'Core', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/extendedLookupList.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/extendedLookupList.pagedef.php
@@ -1,23 +1,13 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'MTTableManager',
         'view' => 'iframe',
         'listClass' => 'TCMSListManagerExtendedLookup',
         '_suppressHistory' => true,
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/extendedLookupListInstances.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/extendedLookupListInstances.pagedef.php
@@ -1,23 +1,13 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'MTTableManager',
         'view' => 'iframe',
         'listClass' => 'TCMSListManagerExtendedLookupModuleInstance',
         '_suppressHistory' => true,
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/gmap.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/gmap.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSGMap', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSGMap', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/iconlist.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/iconlist.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSiconList', 'view' => 'standard', 'iconPath' => '/images/nav_icons/'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSiconList', 'view' => 'standard', 'iconPath' => '/images/nav_icons/'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/interface.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/interface.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_window_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSInterface', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSInterface', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/listtable.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/listtable.pagedef.php
@@ -1,12 +1,9 @@
 <?php
 
-// main layout
 $layoutTemplate = 'tablemanager';
+$moduleList = array('tablemanager' => array('model' => 'MTTableManager', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'tablemanager' => array('model' => 'MTTableManager', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/login.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/login.pagedef.php
@@ -1,12 +1,7 @@
 <?php
 
-// main layout
 $layoutTemplate = 'default';
+$moduleList = array('contentmodule' => array('model' => 'MTLogin', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'contentmodule' => array('model' => 'MTLogin', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/main.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/main.pagedef.php
@@ -1,12 +1,9 @@
 <?php
 
-// main layout
 $layoutTemplate = 'default';
+$moduleList = array('contentmodule' => array('model' => 'MTMenuManager', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'contentmodule' => array('model' => 'MTMenuManager', 'view' => 'standard'), 'breadcrumb' => array('model' => 'MTHeader', 'view' => 'breadcrumb'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/mltfield.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/mltfield.pagedef.php
@@ -1,23 +1,13 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'MTTableManager',
         'view' => 'mltField',
         '_suppressHistory' => true,
         'listClass' => 'TCMSListManagerMLT',
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/mltfieldList.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/mltfieldList.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'CMSFieldMLTList', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSFieldMLTList', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/outbox.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/outbox.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'empty';
-
-// modules...
 $moduleList = array('main' => array('model' => 'CMSDeliverFile', 'view' => 'direct'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/passthrough.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/passthrough.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'empty';
-
-// modules...
 $moduleList = array('main' => array('model' => 'MTPassThrough', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/pkgCmsLicenseManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/pkgCmsLicenseManager.pagedef.php
@@ -1,13 +1,7 @@
 <?php
 
-// main layout
 $layoutTemplate = 'default';
+$moduleList = array('contentmodule' => array('model' => 'TPkgCmsLicenseManager_MTLicenseManager', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'),
-                    'contentmodule' => array('model' => 'TPkgCmsLicenseManager_MTLicenseManager', 'view' => 'standard'), );
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/runcrons.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/runcrons.pagedef.php
@@ -1,12 +1,4 @@
 <?php
 
-// main layout
 $layoutTemplate = 'runcrons';
-
-// modules...
 $moduleList = array('main' => array('model' => 'CMSRunCrons', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}

--- a/src/CoreBundle/Resources/BackendPageDefs/tableManagerDocumentManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableManagerDocumentManager.pagedef.php
@@ -1,14 +1,7 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
 $moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
     'contentmodule' => array(
         'model' => 'MTTableManager',
         'view' => 'wysiwygImageChooser',
@@ -17,7 +10,4 @@ $moduleList = array(
     ),
 );
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableManagerDocumentManagerSelected.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableManagerDocumentManagerSelected.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableManager', 'view' => 'wysiwygImageChooser', '_suppressHistory' => true, 'listClass' => 'TCMSListManagerDocumentManagerSelected'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableManager', 'view' => 'wysiwygImageChooser', '_suppressHistory' => true, 'listClass' => 'TCMSListManagerDocumentManagerSelected'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableManagerMediaManager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableManagerMediaManager.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableManager', 'view' => 'wysiwygImageChooser', '_suppressHistory' => true, 'listClass' => 'TCMSListManagerMediaManager'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableManager', 'view' => 'wysiwygImageChooser', '_suppressHistory' => true, 'listClass' => 'TCMSListManagerMediaManager'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableManagerWYSIWYGImages.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableManagerWYSIWYGImages.pagedef.php
@@ -1,23 +1,13 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'MTTableManager',
         'view' => 'wysiwygImageChooser',
         '_suppressHistory' => true,
         'listClass' => 'TCMSListManagerWYSIWYGImage',
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableeditor.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableeditor.pagedef.php
@@ -1,12 +1,14 @@
 <?php
 
-// main layout
 $layoutTemplate = 'default';
+$moduleList = [
+    'contentmodule' => [
+        'model' => 'MTTableEditor',
+        'view' => 'standard',
+    ],
+];
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'contentmodule' => array('model' => 'MTTableEditor', 'view' => 'standard'), 'breadcrumb' => array('model' => 'MTHeader', 'view' => 'breadcrumb'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableeditorPopup.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableeditorPopup.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableEditorComponent', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableEditorComponent', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tableeditorfield.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tableeditorfield.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableEditor', 'view' => 'field', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableEditor', 'view' => 'field', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tablemanager.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tablemanager.pagedef.php
@@ -1,12 +1,14 @@
 <?php
 
-// main layout
 $layoutTemplate = 'default';
+$moduleList = [
+    'contentmodule' => [
+        'model' => 'MTTableManager',
+        'view' => 'standard',
+    ],
+];
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'contentmodule' => array('model' => 'MTTableManager', 'view' => 'standard'), 'breadcrumb' => array('model' => 'MTHeader', 'view' => 'breadcrumb'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tablemanagercomponent.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tablemanagercomponent.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableManagerComponent', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableManagerComponent', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/tablemanagerframe.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/tablemanagerframe.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'frame';
+$moduleList = array('contentmodule' => array('model' => 'MTTableManager', 'view' => 'iframe', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'MTTableManager', 'view' => 'iframe', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/templateengine.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/templateengine.pagedef.php
@@ -1,7 +1,9 @@
 <?php
 
-// main layout
 $layoutTemplate = 'templateengine';
+$moduleList = array('templateengine' => array('model' => 'CMSTemplateEngine', 'view' => 'main'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'), 'templateengine' => array('model' => 'CMSTemplateEngine', 'view' => 'main'), 'breadcrumb' => array('model' => 'MTHeader', 'view' => 'breadcrumb'));
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/templateengineplain.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/templateengineplain.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'templateengineplain';
+$moduleList = array('templateengine' => array('model' => 'CMSTemplateEngine', 'view' => 'main'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'templateengine' => array('model' => 'CMSTemplateEngine', 'view' => 'main'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/treenodeselect.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/treenodeselect.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
+$moduleList = array('contentmodule' => array('model' => 'CMSTreeNodeSelect', 'view' => 'standard'));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'CMSTreeNodeSelect', 'view' => 'standard'));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/treenodeselectWYSIWYG.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/treenodeselectWYSIWYG.pagedef.php
@@ -1,21 +1,11 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_iframe';
-
-// modules...
 $moduleList = array(
-    'pagetitle' => array(
-        'model' => 'MTHeader',
-        'view' => 'title',
-    ),
     'contentmodule' => array(
         'model' => 'CMSTreeNodeSelectWYSIWYG',
         'view' => 'standard',
     ),
 );
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/BackendPageDefs/versioninfo.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/versioninfo.pagedef.php
@@ -1,12 +1,6 @@
 <?php
 
-// main layout
 $layoutTemplate = 'popup_window_iframe';
+$moduleList = array('contentmodule' => array('model' => 'esono\cmsversioninfo\MTVersionInfo', 'view' => 'standard', '_suppressHistory' => true));
 
-// modules...
-$moduleList = array('pagetitle' => array('model' => 'MTHeader', 'view' => 'title'), 'contentmodule' => array('model' => 'esono\cmsversioninfo\MTVersionInfo', 'view' => 'standard', '_suppressHistory' => true));
-
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -822,5 +822,9 @@
 
         <service id="cmsPkgCore.tableEditorListFieldState" class="TTableEditorListFieldState" public="true" />
 
+        <service id="chameleon_system_core.module.sidebar.sidebar_backend_module" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\Sidebar\SidebarBackendModule" shared="false">
+            <argument type="service" id="chameleon_system_core.language_service"/>
+            <tag name="chameleon_system.module" />
+        </service>
     </services>
 </container>

--- a/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
+++ b/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
@@ -1,0 +1,65 @@
+;(function ($, window, document, undefined) {
+    "use strict";
+
+    const pluginName = "chameleonSystemSidebarMenu";
+
+    function Plugin(baseElement) {
+        this.$baseElement = $(baseElement);
+        this.init();
+    }
+    $.extend(Plugin.prototype, {
+        init: function () {
+            const self = this,
+                  filterElement = this.$baseElement.find('.sidebar-filter-input')
+            ;
+            filterElement.on('keyup', self.filter.bind(this));
+
+            $.extend($.expr[':'], {
+                'chameleonContainsCaseInsensitive': function(elem, i, match, array) {
+                    return (elem.textContent || elem.innerText || '').toLowerCase().indexOf((match[3] || "").toLowerCase()) >= 0;
+                }
+            });
+        },
+        filter: function (event) {
+            const searchTerm = event.target.value;
+            if ('' === searchTerm) {
+                this.$navTitles.removeClass('d-none');
+                this.$navItems.removeClass('d-none');
+
+                return;
+            }
+            if ('undefined' === typeof this.$navItems) {
+                this.$navTitles = this.$baseElement.find('.nav-title');
+                this.$navItems = this.$baseElement.find('.nav-item');
+            }
+
+            this.$navTitles.addClass('d-none');
+            this.$navItems.addClass('d-none');
+            const $matchingNavItems = this.$navItems.find(":chameleonContainsCaseInsensitive('" + searchTerm + "')").closest('.nav-item');
+            $matchingNavItems.removeClass('d-none');
+            // Find title for matching nav items directly after title.
+            $matchingNavItems.prev('.nav-title').removeClass('d-none');
+            // Find title for further matching nav items.
+            $matchingNavItems.prevUntil('.nav-title').prev('.nav-title').removeClass('d-none');
+        }
+    });
+
+    $.fn[pluginName] = function (state, options) {
+        if (typeof state === 'string') {
+            //call a method inside plugin
+            return $.data(this[0], "plugin_" + pluginName)[state](options);
+        }
+
+        return this.each(function () {
+            if (!$.data(this, "plugin_" + pluginName)) {
+                $.data(this, "plugin_" + pluginName, new Plugin(this, state, options));
+            } else {
+                $.data(this, "plugin_" + pluginName).open();
+            }
+        });
+    };
+})(jQuery, window, document);
+
+(function ($) {
+    $('.sidebar').chameleonSystemSidebarMenu();
+})(jQuery);

--- a/src/CoreBundle/Resources/translations/admin.de.xliff
+++ b/src/CoreBundle/Resources/translations/admin.de.xliff
@@ -2514,6 +2514,11 @@
                 <source>chameleon_system_core.admin_message.button_title</source>
                 <target>Achtung</target>
             </trans-unit>
+
+            <trans-unit id="chameleon_system_core.sidebar.filter_menu">
+                <source>chameleon_system_core.sidebar.filter_menu</source>
+                <target>Menü filtern</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/translations/admin.en.xliff
+++ b/src/CoreBundle/Resources/translations/admin.en.xliff
@@ -2514,6 +2514,11 @@
                 <source>chameleon_system_core.admin_message.button_title</source>
                 <target>Attention</target>
             </trans-unit>
+
+            <trans-unit id="chameleon_system_core.sidebar.filter_menu">
+                <source>chameleon_system_core.sidebar.filter_menu</source>
+                <target>Filter menu</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
@@ -1,0 +1,21 @@
+<nav class="sidebar-nav">
+    <input
+            type="text"
+            class="sidebar-filter-input form-control"
+            placeholder="{{ 'chameleon_system_core.sidebar.filter_menu'|trans }}"
+            autocomplete="off"
+    />
+    <ul class="nav">
+        {% for category in menuItems %}
+            <li class="nav-title">{{ category.name }}</li>
+            {% for menuItem in category.menuItems %}
+                <li class="nav-item">
+                    <a href="{{ menuItem.url }}" class="nav-link">
+                        <i class="nav-icon icon-drop"></i>{{ menuItem.name }}
+                    </a>
+                </li>
+            {% endfor %}
+        {% endfor %}
+    </ul>
+</nav>
+<button class="sidebar-minimizer brand-minimizer" type="button" /></button>

--- a/src/CoreBundle/Tests/TableEditor/NestedSet/NestedSetHelperTest.php
+++ b/src/CoreBundle/Tests/TableEditor/NestedSet/NestedSetHelperTest.php
@@ -188,7 +188,7 @@ class NestedSetHelperTest extends TestCase
     }
 
     /**
-     * @param $nodeName
+     * @param string $nodeName
      *
      * @return NestedSetHelperTestNodeMock
      */
@@ -205,7 +205,7 @@ class NestedSetHelperTest extends TestCase
         $node = $this->getNodeData($this->nodeName);
         $this->nestedSetHelper->deleteNode($node->getId());
 
-        // now we need to delete the node and all it's children
+        // Now we need to delete the node and all children
         $this->deleteRecursive($node->getId());
     }
 

--- a/src/CoreBundle/private/core/TModelBase.class.php
+++ b/src/CoreBundle/private/core/TModelBase.class.php
@@ -773,6 +773,15 @@ class TModelBase
             $sViewPathReference = &$this->viewTemplate;
         } else {
             $oModule = $this->getModuleObject($this->aModuleConfig['model'], 'classname');
+            if (null === $oModule) {
+                $errorMessage = sprintf('Error: Module "%s" not found', $this->aModuleConfig['model']);
+                if (true === _DEVELOPMENT_MODE) {
+                    $response->setContent($errorMessage);
+                }
+                $this->getLogger()->warning($errorMessage);
+
+                return $response;
+            }
 
             $oRenderer->AddMapper($this);
             $oRenderer->AddSourceObject('instanceID', $this->instanceID);

--- a/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem.class.php
+++ b/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem.class.php
@@ -10,20 +10,19 @@
  */
 
 /**
- * the base class for all menu (category) items in the cms. all menu items
- * must inherit from this.
-/**/
+ * The base class for all menu (category) items in the CMS. All menu items must inherit from this.
+ *
+ * @deprecated since 6.3.0 - only used for deprecated classic main menu
+ */
 class TCMSMenuItem
 {
     /**
-     * holds the menu item data.
-     *
      * @var array
      */
-    public $data = null;
+    public $data;
 
     /**
-     * set the data for the item.
+     * Sets data for the item.
      *
      * @param array $data
      */
@@ -33,7 +32,7 @@ class TCMSMenuItem
     }
 
     /**
-     * return an html link used to call the items detail page.
+     * Returns an HTML link used to call the item's detail page.
      *
      * @return string
      */

--- a/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem_Module.class.php
+++ b/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem_Module.class.php
@@ -10,8 +10,10 @@
  */
 
 /**
- * a standard CMS Module.
-/**/
+ * A standard CMS Module.
+ *
+ * @deprecated since 6.3.0 - only used for deprecated classic main menu
+ */
 class TCMSMenuItem_Module extends TCMSMenuItem
 {
     /**

--- a/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem_Table.class.php
+++ b/src/CoreBundle/private/library/classes/MenuItems/TCMSMenuItem_Table.class.php
@@ -10,8 +10,10 @@
  */
 
 /**
- * a Table item.
-/**/
+ * A table item.
+ *
+ * @deprecated since 6.3.0 - only used for deprecated classic main menu
+ */
 class TCMSMenuItem_Table extends TCMSMenuItem
 {
     /**

--- a/src/CoreBundle/private/library/classes/TCMSPageDefinitionFile.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSPageDefinitionFile.class.php
@@ -213,6 +213,7 @@ class TCMSPageDefinitionFile
         $pageLoaded = false;
         $file = $this->sPageDefPath.'/'.$sPagedef.'.pagedef.php';
         if (file_exists($file)) {
+            include_once __DIR__.'/pagedefFunctions.inc.php';
             include $file;
             if (isset($templateName)) {
                 $this->templateName = $templateName;

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSModule.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSModule.class.php
@@ -35,9 +35,6 @@ class TCMSModule extends TCMSRecord
             $url .= '&amp;_pagedefType='.$pagedefType;
         }
         $url = TGlobal::OutHTML($url).$urlParams;
-        if ('1' == $this->sqlData['show_as_popup']) {
-            $url = "javascript:CreateModalIFrameDialogCloseButton('{$url}',".TGlobal::OutHTML($this->sqlData['width']).','.TGlobal::OutHTML($this->sqlData['height']).');';
-        }
 
         return $url;
     }

--- a/src/CoreBundle/private/library/classes/pagedefFunctions.inc.php
+++ b/src/CoreBundle/private/library/classes/pagedefFunctions.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+function addDefaultPageTitle(array &$moduleList): void
+{
+    $moduleList['pagetitle'] = [
+        'model' => 'MTHeader',
+        'view' => 'title',
+    ];
+}
+
+function addDefaultHeader(array &$moduleList): void
+{
+    $moduleList['headerimage'] = [
+        'model' => 'MTHeader',
+        'view' => 'standard',
+    ];
+}
+
+function addDefaultBreadcrumb(array &$moduleList): void
+{
+    $moduleList['breadcrumb'] = [
+        'model' => 'MTHeader',
+        'view' => 'breadcrumb',
+    ];
+}
+
+function addDefaultSidebar(array &$moduleList): void
+{
+    $moduleList['sidebar'] = [
+        'model' => 'chameleon_system_core.module.sidebar.sidebar_backend_module',
+        'moduleType' => '@ChameleonSystemCoreBundle',
+        'view' => 'standard',
+    ];
+}

--- a/src/CoreBundle/private/modules/MTHeader/views/standard.view.php
+++ b/src/CoreBundle/private/modules/MTHeader/views/standard.view.php
@@ -5,7 +5,7 @@ use ChameleonSystem\CoreBundle\ServiceLocator;
 
 $translator = ServiceLocator::get('translator');
 ?>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark" role="navigation" id="header-nav">
+<nav class="navbar navbar-expand-lg" role="navigation" id="header-nav">
     <div class="container-fluid">
         <a href="<?=PATH_CMS_CONTROLLER; ?>?_rmhist=true&_histid=0" class="navbar-brand"><img src="<?=TGlobal::OutHTML($sLogoURL); ?>" /></a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#cmsTopNavbar">

--- a/src/CoreBundle/private/rendering/layouts/default.layout.php
+++ b/src/CoreBundle/private/rendering/layouts/default.layout.php
@@ -3,6 +3,9 @@
 <?php $modules->GetModule('headerimage'); ?>
 </header>
 <div id="cmscontainer" class="app-body">
+    <div class="sidebar">
+        <?php $modules->GetModule('sidebar') ?>
+    </div>
     <main class="main" id="cmscontentcontainer">
         <?php $modules->GetModule('breadcrumb'); ?>
         <div class="container-fluid">

--- a/src/CoreBundle/private/rendering/layouts/includes/cms_head_data.inc.php
+++ b/src/CoreBundle/private/rendering/layouts/includes/cms_head_data.inc.php
@@ -1,14 +1,20 @@
 <?php
+/**
+ * @var TModuleLoader $modules
+ */
+
 if (false === headers_sent()) {
     header('Content-Type: text/html; charset=UTF-8');
 }
-include dirname(__FILE__).'/cms_page_header.inc.php';
-include dirname(__FILE__).'/global-php-vars.inc.php';
+include __DIR__.'/cms_page_header.inc.php';
+include __DIR__.'/global-php-vars.inc.php';
 
 if (false === isset($cssClasses)) {
-    $cssClasses = 'app header-fixed';
-} else {
-    $cssClasses .= 'app header-fixed';
+    $cssClasses = '';
+}
+$cssClasses .= ' app header-fixed';
+if (true === $modules->hasModule('sidebar')) {
+    $cssClasses .= ' sidebar-fixed sidebar-lg-show';
 }
 
 if (false === isset($bodyAttributes)) {

--- a/src/CoreBundle/private/rendering/layouts/templateengine.layout.php
+++ b/src/CoreBundle/private/rendering/layouts/templateengine.layout.php
@@ -3,6 +3,9 @@
     <?php $modules->GetModule('headerimage'); ?>
 </header>
 <div id="cmscontainer" class="app-body">
+    <div class="sidebar">
+        <?php $modules->GetModule('sidebar') ?>
+    </div>
     <main class="main" id="cmscontentcontainer">
         <?php $modules->GetModule('breadcrumb'); ?>
         <?php $modules->GetModule('templateengine'); ?>

--- a/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManager.pagedef.php
+++ b/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManager.pagedef.php
@@ -8,12 +8,13 @@ if ($urlGenerator->openStandaloneMediaManagerInNewWindow()) {
     $layoutTemplate = 'popup_iframe';
 }
 
-$moduleList = array(
-    'pagetitle' => array('model' => 'MTHeader', 'view' => 'title'),
-    'headerimage' => array('model' => 'MTHeader', 'view' => 'standard'),
-    'contentmodule' => array(
+$moduleList = [
+    'contentmodule' => [
         'model' => 'chameleon_system_media_manager.backend_module.media_manager',
         'moduleType' => '@ChameleonSystemMediaManagerBundle',
         'view' => 'full',
-    ),
-);
+    ],
+];
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManagerLegacyList.pagedef.php
+++ b/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManagerLegacyList.pagedef.php
@@ -1,11 +1,11 @@
 <?php
 
 $layoutTemplate = 'mediaManager';
-
 $moduleList = array(
-    'pagetitle' => array('model' => 'MTHeader', 'view' => 'title'),
     'content' => array(
         'model' => 'chameleon_system_media_manager.backend_module.media_manager_legacy_list',
         'view' => 'standard',
     ),
 );
+
+addDefaultPageTitle($moduleList);

--- a/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManagerPickImage.pagedef.php
+++ b/src/MediaManagerBundle/Resources/BackendPageDefs/mediaManagerPickImage.pagedef.php
@@ -6,10 +6,11 @@ $urlGenerator = ServiceLocator::get('chameleon_system_core.media_manager.url_gen
 $layoutTemplate = 'popup_iframe';
 
 $moduleList = array(
-    'pagetitle' => array('model' => 'MTHeader', 'view' => 'title'),
     'contentmodule' => array(
         'model' => 'chameleon_system_media_manager.backend_module.media_manager',
         'moduleType' => '@ChameleonSystemMediaManagerBundle',
         'view' => 'full',
     ),
 );
+
+addDefaultPageTitle($moduleList);

--- a/src/SanityCheckChameleonBundle/Resources/BackendPageDefs/sanitycheck.pagedef.php
+++ b/src/SanityCheckChameleonBundle/Resources/BackendPageDefs/sanitycheck.pagedef.php
@@ -1,20 +1,15 @@
 <?php
 
-// main layout
-$layoutTemplate = 'popup_window_iframe';
-
-// modules...
-$moduleList = array(
-    'pagetitle' => array('model' => 'MTHeader', 'view' => 'title'),
-    'contentmodule' => array(
+$layoutTemplate = 'default';
+$moduleList = [
+    'contentmodule' => [
         'model' => 'chameleon_system_sanity_check_chameleon.module.cms_sanity_check',
         'view' => 'standard',
         'moduleType' => '@ChameleonSystemSanityCheckChameleonBundle',
-        '_suppressHistory' => true,
-    ),
-);
+    ],
+];
 
-// this line needs to be included... do not touch
-if (!is_array($moduleList)) {
-    $layoutTemplate = '';
-}
+addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#100
| License       | MIT

Adds a sidebar menu for the backend.
This PR also contains some cleanup. I needed a way to inject the sidebar module for lots of pagedefs, and adding in the previous ways seemed a bit too low-tech, so I added helper functions that aid in adding backend modules.

Yet to do:
- Remember if the user minimized the sidebar in the session, so that it doesn't pop up after each page switch.
- Wait for https://github.com/chameleon-system/chameleon-base/pull/151 so that we can finish the design.
- Decide on a final width of the sidebar so that most menu items won't cause a line break. Maybe rename some menu items if they're too long (also see https://github.com/chameleon-system/chameleon-system/issues/155).
- Order menu items. Currently they are sorted alphabetically just as in the classic main menu, but the items should have fixed order (either see https://github.com/chameleon-system/chameleon-system/issues/155). For this reason, SidebarBackendModule isn't completely polished yet, as menu initialization might change significantly.