### PR TITLE
ref #277: field help texts without popovers

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -810,7 +810,7 @@ function SetChangedDataMessage() {
 
 CHAMELEON.CORE.MTTableEditor.initHelpTexts = function () {
     $(".help-text-button").click(function () {
-        var helpTextId = '#tooltip-' + $(this).attr("data-helptextId");
+        var helpTextId = '#helptext-' + $(this).attr("data-helptextId");
         $(helpTextId).toggle();
     });
 };

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -712,11 +712,7 @@ CHAMELEON.CORE.MTTableEditor.DeleteRecordWithCustomConfirmMessage = function (sC
     }
 };
 
-$(document).ready(function () {
-    CHAMELEON.CORE.MTTableEditor.initTabs();
-    CHAMELEON.CORE.MTTableEditor.initDateTimePickers();
-    CHAMELEON.CORE.MTTableEditor.initSelectBoxes();
-});
+
 
 CHAMELEON.CORE.MTTableEditor.initTabs = function () {
     var url = document.URL;
@@ -812,7 +808,19 @@ function SetChangedDataMessage() {
     CHAMELEON.CORE.MTTableEditor.initInputChangeObservation();
 }
 
+CHAMELEON.CORE.MTTableEditor.initHelpTexts = function () {
+    $(".help-text-button").click(function () {
+        var helpTextId = '#tooltip-' + $(this).attr("data-helptextId");
+        $(helpTextId).toggle();
+    });
+};
+
+
 $(document).ready(function () {
+    CHAMELEON.CORE.MTTableEditor.initTabs();
+    CHAMELEON.CORE.MTTableEditor.initDateTimePickers();
+    CHAMELEON.CORE.MTTableEditor.initSelectBoxes();
     CHAMELEON.CORE.MTTableEditor.initInputChangeObservation();
     CHAMELEON.CORE.MTTableEditor.addCheckBoxSwitchClickEvent('label.switch input[type=checkbox]');
+    CHAMELEON.CORE.MTTableEditor.initHelpTexts();
 });

--- a/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
@@ -205,7 +205,7 @@
     color: #999;
 }
 
-.tooltipContainer {
+.helptextContainer {
     display: none;
 }
 

--- a/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
@@ -201,18 +201,12 @@
     padding-top: 3px;
 }
 
+.help-text-button i {
+    color: #999;
+}
+
 .tooltipContainer {
-    background-color: #F8F2AA;
-    color: #0B224B;
-    padding: 8px;
-    z-index: 10;
-    display: block;
-    font-family: Arial, helvetica, sans-serif;
-    font-size: 11px;
-    border: 2px solid #FFB608;
-    line-height: 16px;
-    width: 70%;
-    margin-bottom: 20px;
+    display: none;
 }
 
 #tableEditorHeader th, #tableEditorHeader td, #tableEditorHeader td span, #tableEditorHeader td div {

--- a/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
@@ -42,8 +42,8 @@ while ($oField = $data['oFields']->Next()) {
                 $oFieldConfig->Load($oField->oDefinition->id);
 
                 if (!empty($oField->oDefinition->sqlData['049_helptext'])) {
-                    $sTmpFormTabsContent .= '<span class="help-badge badge badge-info float-right" role="button" data-toggle="popover" data-placement="right" data-content="'.TGlobal::OutHTML(nl2br($oField->oDefinition->sqlData['049_helptext'])).'" data-original-title="'.TGlobal::OutHTML($oFieldConfig->fieldTranslation).'">
-                        <span class="glyphicon glyphicon-info-sign" title="'.TGlobal::OutHTML(TGlobal::Translate('chameleon_system_core.cms_module_table_editor.field_help')).'"></span>
+                    $sTmpFormTabsContent .= '<span class="float-right help-text-button" data-helptextId="'.TGlobal::OutHTML($oField->name).'">
+                        <i class="fas fa-info-circle" title="'.TGlobal::OutHTML(TGlobal::Translate('chameleon_system_core.cms_module_table_editor.field_help')).'"></i>
                     </span>';
                 }
 
@@ -84,8 +84,12 @@ while ($oField = $data['oFields']->Next()) {
             </div>
     	    </th>
           <td class="rightTD col-10">';
+                if (!empty($oField->oDefinition->sqlData['049_helptext'])) {
+                    $sTmpFormTabsContent .= '<div class="tooltipContainer alert alert-info" id="tooltip-'.TGlobal::OutHTML($oField->name).'">'.TGlobal::OutHTML(nl2br($oField->oDefinition->sqlData['049_helptext'])).'</div>';
+                }
                 $sTmpFormTabsContent .= $oField->GetContent();
-                $sTmpFormTabsContent .= '</td>
+                $sTmpFormTabsContent .= '
+           </td>
         </tr>
         ';
             }

--- a/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
@@ -18,14 +18,16 @@ while ($oField = $data['oFields']->Next()) {
             if ($oField->completeRow) { // Headline row
                 $sTmpFormTabsContent .= "<tr><td colspan=\"2\"{$rowColorStyle}>";
                 $sTmpFormTabsContent .= '<div class="fieldSeperator">';
-                if (!empty($oField->oDefinition->sqlData['049_helptext'])) {
-                    $sTmpFormTabsContent .= '<div id="tooltip'.$oField->name.'" style="float:left;" class="badge"><img src="'.TGlobal::GetPathTheme()."/images/icons/icon_info.gif\" width=\"16\" height=\"16\" alt=\"\" onclick=\"$('#tooltip".$oField->name."_content').toggle();\"></div>&nbsp;&nbsp;";
-                }
                 $sTmpFormTabsContent .= $oField->GetContent();
+                if ('' !== $oField->oDefinition->sqlData['049_helptext']) {
+                    $sTmpFormTabsContent .= '<span class="help-text-button" data-helptextId="'.TGlobal::OutHTML($oField->name).'">
+                        <i class="fas fa-info-circle" title="'.TGlobal::OutHTML(TGlobal::Translate('chameleon_system_core.cms_module_table_editor.field_help')).'"></i>
+                    </span>';
+                }
                 $sTmpFormTabsContent .= '</div>';
 
-                if (!empty($oField->oDefinition->sqlData['049_helptext'])) {
-                    $sTmpFormTabsContent .= '<div style="display: none;" id="tooltip'.$oField->name.'_content" class="tooltipContainer">'.nl2br($oField->oDefinition->sqlData['049_helptext']).'</div>';
+                if ('' !== $oField->oDefinition->sqlData['049_helptext']) {
+                    $sTmpFormTabsContent .= '<div class="helptextContainer alert alert-info" id="helptext-'.TGlobal::OutHTML($oField->name).'">'.TGlobal::OutHTML(nl2br($oField->oDefinition->sqlData['049_helptext'])).'</div>';
                 }
                 $sTmpFormTabsContent .= '</td></tr>';
             } else {
@@ -84,8 +86,8 @@ while ($oField = $data['oFields']->Next()) {
             </div>
     	    </th>
           <td class="rightTD col-10">';
-                if (!empty($oField->oDefinition->sqlData['049_helptext'])) {
-                    $sTmpFormTabsContent .= '<div class="tooltipContainer alert alert-info" id="tooltip-'.TGlobal::OutHTML($oField->name).'">'.TGlobal::OutHTML(nl2br($oField->oDefinition->sqlData['049_helptext'])).'</div>';
+                if ('' !== $oField->oDefinition->sqlData['049_helptext']) {
+                    $sTmpFormTabsContent .= '<div class="helptextContainer alert alert-info" id="helptext-'.TGlobal::OutHTML($oField->name).'">'.TGlobal::OutHTML(nl2br($oField->oDefinition->sqlData['049_helptext'])).'</div>';
                 }
                 $sTmpFormTabsContent .= $oField->GetContent();
                 $sTmpFormTabsContent .= '


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#277
| License       | MIT

Here a change was changed back.
For version 6.3 the help texts were displayed with popovers. But this is impractical.
Now it was solved again similar to version 6.2, but with a new icon and an alert box info.
