### PR TITLE
ref #291: fix js-error with field TCMSFieldLookupMultiselectCheckboxe…

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -650,7 +650,7 @@ function markCheckboxes(fieldname) {
         }
     }
 
-    var elements = document.forms['cmseditform'].elements[fieldname + "[]"];
+    var elements = document.querySelectorAll('[name="cmseditform"] input[name^="' + fieldname + '"]');
     for (i = 0; i < elements.length; i++) {
         var element = elements[i];
         if (false === element.disabled) {
@@ -660,7 +660,7 @@ function markCheckboxes(fieldname) {
 }
 
 function invertCheckboxes(fieldname) {
-    var elements = document.forms['cmseditform'].elements[fieldname + "[]"];
+    var elements = document.querySelectorAll('[name="cmseditform"] input[name^="' + fieldname + '"]');
     for (i = 0; i < elements.length; i++) {
         var element = elements[i];
         if (false === element.disabled) {


### PR DESCRIPTION
…s: select/deselect all

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no 
| Deprecations? | no 
| Fixed issues  | chameleon-system/chameleon-system#291
| License       | MIT

Field-typ TCMSFieldLookupMultiselectCheckboxes:
From Version 6.3 there was an JS-error with select all / deselect all:
tableEditor.js:655 Uncaught TypeError: Cannot read property 'length' of undefined at markCheckboxes

and the select all / deselect all didn't work.

See, for example, Articles, field product type. Try selecting all items and/or deselecting them.