### PR TITLE
ref #265: replace icon: add table cms_dark_site_content to update

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1547452870.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1547452870.inc.php
@@ -230,7 +230,8 @@ $iconMapping = array(
     'shop_search_cloud_word' => 'fas fa-cloud',
     'cms_locals' => 'fas fa-map-marked-alt',
     'cms_portal' => 'fas fa-home',
-    'shop_manufacturer' => 'fas fa-industry'
+    'shop_manufacturer' => 'fas fa-industry',
+    'cms_dark_site_content' => 'fas fa-sign-out-alt',
 );
 
 foreach ($iconMapping as $tableName => $iconName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#265
| License       | MIT

Code review to Issue "Replace main menu icons with font awesome icons": Add table cms_dark_site_content to update file and set the standard icon for this table.
