### PR TITLE
Feature/301 navigation tree styling

### DIFF
--- a/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTree.pagedef.php
+++ b/src/CoreBundle/Resources/BackendPageDefs/CMSModulePageTree.pagedef.php
@@ -1,6 +1,9 @@
 <?php
 
-$layoutTemplate = 'frame';
+$layoutTemplate = 'default';
 $moduleList = array('contentmodule' => array('model' => 'CMSModulePageTree', 'view' => 'standard'));
 
 addDefaultPageTitle($moduleList);
+addDefaultHeader($moduleList);
+addDefaultBreadcrumb($moduleList);
+addDefaultSidebar($moduleList);

--- a/src/CoreBundle/Resources/public/javascript/jquery/contextmenu/contextmenu.css
+++ b/src/CoreBundle/Resources/public/javascript/jquery/contextmenu/contextmenu.css
@@ -1,3 +1,7 @@
+/**
+ * @deprecated since 6.3.0 (duplicate file).
+ */
+
 #jqContextMenu ul {
   list-style-image: none;
   list-style-position: outside;

--- a/src/CoreBundle/Resources/public/themes/standard/css/simpleTree.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/simpleTree.css
@@ -1,3 +1,7 @@
+.simple-tree-card {
+	padding-left: 2.5rem !important;
+}
+
 .simpleTree
 {
 	margin:0;

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
@@ -269,7 +269,7 @@ class TCMSFieldPageTreeNode extends TCMSFieldTreeNode
     {
         $aIncludes = parent::GetCMSHtmlHeadIncludes();
 
-        $url = PATH_CMS_CONTROLLER.'?'.TTools::GetArrayAsURLForJavascript(array('pagedef' => 'CMSModulePageTreePlain', 'table' => 'cms_tpl_page', 'rootID' => '99', 'id' => $this->oTableRow->id));
+        $url = PATH_CMS_CONTROLLER.'?'.TTools::GetArrayAsURLForJavascript(array('pagedef' => 'CMSModulePageTreePlain', 'table' => 'cms_tpl_page', 'rootID' => '99', 'id' => $this->oTableRow->id, 'isInIframe' => '1'));
         $aIncludes[] = "<script type=\"text/javascript\">
         function loadTreeNodeSelection(fieldName,id) {
           if(document.getElementById('cms_portal_id').options != undefined) {

--- a/src/CoreBundle/private/modules/CMSModulePageTree/CMSModulePageTree.class.php
+++ b/src/CoreBundle/private/modules/CMSModulePageTree/CMSModulePageTree.class.php
@@ -11,8 +11,10 @@
 
 use ChameleonSystem\CoreBundle\CoreEvents;
 use ChameleonSystem\CoreBundle\Event\ChangeNavigationTreeNodeEvent;
+use ChameleonSystem\CoreBundle\ServiceLocator;
 use ChameleonSystem\CoreBundle\TableEditor\NestedSet\NestedSetHelperFactoryInterface;
 use ChameleonSystem\CoreBundle\TableEditor\NestedSet\NestedSetHelperInterface;
+use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -84,6 +86,13 @@ class CMSModulePageTree extends TCMSModelBase
     public function &Execute()
     {
         parent::Execute();
+
+        $this->data['isInIframe'] = false;
+
+        $isInIframe = $this->getInputFilterUtil()->getFilteredInput('isInIframe');
+        if (null !== $isInIframe) {
+            $this->data['isInIframe'] = true;
+        }
 
         $this->data['rootNodeName'] = 'Root';
 
@@ -624,7 +633,7 @@ class CMSModulePageTree extends TCMSModelBase
         $aIncludes[] = '<script src="'.TGlobal::GetStaticURLToWebLib('/javascript/jquery/cookie/jquery.cookie.js').'" type="text/javascript"></script>';
         $aIncludes[] = '<link href="'.TGlobal::GetPathTheme().'/css/simpleTree.css" media="screen" rel="stylesheet" type="text/css" />';
         $aIncludes[] = '<script src="'.TGlobal::GetStaticURLToWebLib('/javascript/jquery/contextmenu/contextmenu.js').'" type="text/javascript"></script>';
-        $aIncludes[] = '<link href="'.TGlobal::GetStaticURLToWebLib('/javascript/jquery/contextmenu/contextmenu.css').'" media="screen" rel="stylesheet" type="text/css" />';
+        $aIncludes[] = '<link href="'.TGlobal::GetPathTheme().'/css/contextmenu.css" rel="stylesheet" type="text/css" />';
 
         return $aIncludes;
     }
@@ -698,7 +707,7 @@ COMMAND;
     protected function getNestedSetHelper()
     {
         /** @var $factory NestedSetHelperFactoryInterface */
-        $factory = \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.table_editor_nested_set_helper_factory');
+        $factory = ServiceLocator::get('chameleon_system_core.table_editor_nested_set_helper_factory');
 
         return $factory->createNestedSetHelper($this->treeTable, 'parent_id', 'entry_sort');
     }
@@ -708,7 +717,7 @@ COMMAND;
      */
     private function getDatabaseConnection()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('database_connection');
+        return ServiceLocator::get('database_connection');
     }
 
     /**
@@ -716,6 +725,11 @@ COMMAND;
      */
     private function getEventDispatcher()
     {
-        return \ChameleonSystem\CoreBundle\ServiceLocator::get('event_dispatcher');
+        return ServiceLocator::get('event_dispatcher');
+    }
+
+    private function getInputFilterUtil(): InputFilterUtilInterface
+    {
+        return ServiceLocator::get('chameleon_system_core.util.input_filter');
     }
 }

--- a/src/CoreBundle/private/modules/CMSModulePageTree/views/standard.view.php
+++ b/src/CoreBundle/private/modules/CMSModulePageTree/views/standard.view.php
@@ -226,49 +226,79 @@
         <?php
         if (true == $data['showAssignDialog']) {
             ?>
-            <li class="firstnode" id="assignpage"><a href="javascript:void(0);"><img
-                src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_tick.gif'); ?>"
-                border="0"><?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_connect_page'); ?></a></li>
+            <li class="firstnode" id="assignpage">
+                <a href="javascript:void(0);">
+                    <i class="fas fa-link mr-2"></i>
+                    <?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_connect_page'); ?>
+                </a>
+            </li>
             <?php
         }
         ?>
-        <li id="editpageconnections"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_edit.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.connected_pages'); ?></a></li>
-        <li id="editpage"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_edit.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_page'); ?></a></li>
-        <li id="editpageconfig"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/application_edit.png'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.list.page_settings'); ?></a></li>
-        <li id="editnode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_edit.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_node'); ?></a></li>
-        <li id="newnode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_new.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.action.new'); ?></a></li>
-        <li id="deletenode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_delete.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.action.delete'); ?></a></li>
+        <li id="editpageconnections">
+            <a href="javascript:void(0);">
+                <i class="fas fa-link mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.connected_pages'); ?>
+            </a>
+        </li>
+        <li id="editpage">
+            <a href="javascript:void(0);">
+                <i class="far fa-edit mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_page'); ?>
+            </a>
+        </li>
+        <li id="editpageconfig">
+            <a href="javascript:void(0);">
+                <i class="fas fa-cog mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.list.page_settings'); ?>
+            </a>
+        </li>
+        <li id="editnode">
+            <a href="javascript:void(0);">
+                <i class="fas fa-sitemap mr-1"></i>
+                <?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_node'); ?>
+            </a>
+        </li>
+        <li id="newnode">
+            <a href="javascript:void(0);">
+                <i class="fas fa-plus mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.action.new'); ?>
+            </a>
+        </li>
+        <li id="deletenode">
+            <a href="javascript:void(0);">
+                <i class="far fa-trash-alt mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.action.delete'); ?>
+            </a>
+        </li>
     </ul>
     <div class="cleardiv">&nbsp;</div>
 </div>
 <div id="RootNodeRightClickMenuContainer" style="display: none;">
     <ul>
-        <li id="newnode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_new.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.action.new'); ?></a></li>
+        <li id="newnode">
+            <a href="javascript:void(0);">
+                <i class="fas fa-plus mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.action.new'); ?>
+            </a>
+        </li>
     </ul>
     <div class="cleardiv">&nbsp;</div>
 </div>
 <div id="RestrictedNodeRightClickMenuContainer" style="display: none;">
     <ul>
-        <li id="editnode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_edit.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_node'); ?></a></li>
-        <li id="newnode"><a href="javascript:void(0);"><img
-            src="<?=TGlobal::GetStaticURLToWebLib('/images/icons/page_new.gif'); ?>"
-            border="0"><?php echo $translator->trans('chameleon_system_core.action.new'); ?></a></li>
+        <li id="editnode">
+            <a href="javascript:void(0);">
+                <i class="far fa-edit mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.cms_module_page_tree.action_edit_node'); ?>
+            </a>
+        </li>
+        <li id="newnode">
+            <a href="javascript:void(0);">
+                <i class="fas fa-plus mr-2"></i>
+                <?php echo $translator->trans('chameleon_system_core.action.new'); ?>
+            </a>
+        </li>
     </ul>
     <div class="cleardiv">&nbsp;</div>
 </div>
@@ -356,47 +386,67 @@
 
     });
 </script>
-<div class="navigationTreeContainer">
-    <ul class="simpleTree">
+
+<?php
+if (false === $isInIframe) {
+?>
+<div class="card">
+    <div class="card-header">
+        <h3>Navigation</h3>
+    </div>
+    <div class="card-body simple-tree-card">
+<?php
+}
+?>
+        <div class="navigationTreeContainer">
+            <ul class="simpleTree">
+                <?php
+                echo $data['sTreeHTML'];
+                ?>
+            </ul>
+
+            <div class="treelegend">
+                <h3>
+                    <span class="nodeIndicatorIcon"></span>
+                    <?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_header'); ?>
+                </h3>
+
+                <div class="text">
+                    <span class="nodeIndicatorIcon"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_node_has_no_page'); ?></span>
+                </div>
+
+                <div class="otherConnectedNode">
+                    <span class="nodeIndicatorIcon"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_has_connected_pages'); ?></span>
+                </div>
+
+                <div class="activeConnectedNode">
+                    <span class="nodeIndicatorIcon"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page'); ?></span>
+                </div>
+
+                <div class="restrictedPage">
+                    <span class="nodeIndicatorIcon iconRestricted" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/tree/lock.png')); ?>');"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page'); ?></span>
+                </div>
+
+                <div class="legendLine">
+                    <span class="nodeIndicatorIcon iconHidden" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/tree/hidden.png')); ?>');"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_hidden'); ?></span>
+                </div>
+
+                <div class="legendLine">
+                    <span class="nodeIndicatorIcon iconExternalLink" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/icon_external_link.gif')); ?>');"></span>
+                    <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_external_link'); ?></span>
+                </div>
+            </div>
+        </div>
         <?php
-            echo $data['sTreeHTML'];
+        if (false === $isInIframe) {
         ?>
-    </ul>
-
-    <div class="treelegend">
-        <h3>
-            <span class="nodeIndicatorIcon"></span>
-            <?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_header'); ?>
-        </h3>
-
-        <div class="text">
-            <span class="nodeIndicatorIcon"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_node_has_no_page'); ?></span>
-        </div>
-
-        <div class="otherConnectedNode">
-            <span class="nodeIndicatorIcon"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_has_connected_pages'); ?></span>
-        </div>
-
-        <div class="activeConnectedNode">
-            <span class="nodeIndicatorIcon"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page'); ?></span>
-        </div>
-
-        <div class="restrictedPage">
-            <span class="nodeIndicatorIcon iconRestricted" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/tree/lock.png')); ?>');"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page'); ?></span>
-        </div>
-
-        <div class="legendLine">
-            <span class="nodeIndicatorIcon iconHidden" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/tree/hidden.png')); ?>');"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_hidden'); ?></span>
-        </div>
-
-        <div class="legendLine">
-            <span class="nodeIndicatorIcon iconExternalLink" style="background-image: url('<?php echo TGlobal::OutHTML(TGlobal::GetStaticURLToWebLib('/images/icon_external_link.gif')); ?>');"></span>
-            <span><?=$translator->trans('chameleon_system_core.cms_module_page_tree.legend_external_link'); ?></span>
-        </div>
     </div>
 </div>
+<?php
+}
+

--- a/src/CoreBundle/private/modules/CMSTemplateEngine/views/parts/navi.inc.php
+++ b/src/CoreBundle/private/modules/CMSTemplateEngine/views/parts/navi.inc.php
@@ -1,9 +1,11 @@
-<div class="btn-group">
+<div class="row button-element">
         <?php
         $data['oMenuItems']->GoToStart();
         /** @var $oMenuItem TCMSTableEditorMenuItem */
         while ($oMenuItem = $data['oMenuItems']->Next()) {
-            echo $oMenuItem->GetMenuItemHTML();
+            echo '<div class="button-item col-12 col-sm-6 col-md-4 col-lg-auto">';
+                echo $oMenuItem->GetMenuItemHTML();
+            echo '</div>';
         }
         ?>
 </div>

--- a/src/CoreBundle/private/modules/MTHeader/views/standard.view.php
+++ b/src/CoreBundle/private/modules/MTHeader/views/standard.view.php
@@ -67,7 +67,7 @@ if (false === isset($data['oUser'])) {
                     if ($data['showNaviManager']) {
                         $windowTitle = $translator->trans('chameleon_system_core.cms_module_page_tree.headline');
                         $fieldName = 'mainNavNavi';
-                        $url = PATH_CMS_CONTROLLER.'?pagedef=CMSModulePageTreePlain&table=cms_tpl_page&noassign=1&rootID='.$data['startTreeID'];
+                        $url = PATH_CMS_CONTROLLER.'?pagedef=CMSModulePageTree&table=cms_tpl_page&noassign=1&rootID='.$data['startTreeID'];
                     ?>
                         <li class="nav-item px-2">
                             <a href="<?= TGlobal::OutHTML($url) ?>" class="nav-link" title="<?=TGlobal::OutHTML($translator->trans('chameleon_system_core.cms_module_header.action_edit_navigation_help')); ?>">

--- a/src/CoreBundle/private/rendering/layouts/templateengine.layout.php
+++ b/src/CoreBundle/private/rendering/layouts/templateengine.layout.php
@@ -1,5 +1,5 @@
 <?php require_once PATH_LAYOUTTEMPLATES.'/includes/cms_head_data.inc.php'; ?>
-<header class="app-header">
+<header class="app-header navbar">
     <?php $modules->GetModule('headerimage'); ?>
 </header>
 <div id="cmscontainer" class="app-body">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master 
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no 
| Fixed issues  | chameleon-system/chameleon-system#301   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Styling Navigation Tree:
The navigation tree is called in two places. First from the header area and second when a navigation point is assigned to a page. In the second case in an iFrame. This has to be differentiated.

