### PR TITLE
Fix/306 TCMSFieldDateTime with seconds

### DIFF
--- a/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
@@ -224,8 +224,8 @@ label.switch .switch-slider::after {
     transition: inherit;
 }
 
-/**
- * TCMSFieldDateTime with seconds. Overwrite of an styling-error comes from the plugin datetimepicker.
+/*
+ * TCMSFieldDateTime with seconds. Overwriting a styling error that comes from the datetimepicker plugin.
  */
 .bootstrap-datetimepicker-widget.dropdown-menu.wider {
     width: 38em !important;

--- a/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/tableeditcontainer.css
@@ -223,3 +223,10 @@ label.switch .switch-slider::after {
     content: attr(data-inactive);
     transition: inherit;
 }
+
+/**
+ * TCMSFieldDateTime with seconds. Overwrite of an styling-error comes from the plugin datetimepicker.
+ */
+.bootstrap-datetimepicker-widget.dropdown-menu.wider {
+    width: 38em !important;
+}

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateTime.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateTime.class.php
@@ -26,7 +26,7 @@ class TCMSFieldDateTime extends TCMSField
         $viewRenderer->AddSourceObject('fieldName', $this->name);
         $viewRenderer->AddSourceObject('fieldValue', $this->_GetHTMLValue());
         $viewRenderer->AddSourceObject('language', TCMSUser::GetActiveUser()->GetCurrentEditLanguage());
-        $viewRenderer->AddSourceObject('datetimepickerFormat', '');
+        $viewRenderer->AddSourceObject('datetimepickerFormat', 'L LTS');
         $viewRenderer->AddSourceObject('datetimepickerSideBySide', 'true');
         $viewRenderer->AddSourceObject('datetimepickerWithIcon', false);
 

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateTimeNow.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateTimeNow.class.php
@@ -24,7 +24,7 @@ class TCMSFieldDateTimeNow extends TCMSFieldDateTime
         $viewRenderer->AddSourceObject('fieldName', $this->name);
         $viewRenderer->AddSourceObject('fieldValue', $this->_GetHTMLValue());
         $viewRenderer->AddSourceObject('language', TCMSUser::GetActiveUser()->GetCurrentEditLanguage());
-        $viewRenderer->AddSourceObject('datetimepickerFormat', '');
+        $viewRenderer->AddSourceObject('datetimepickerFormat', 'L LTS');
         $viewRenderer->AddSourceObject('datetimepickerSideBySide', 'true');
         $viewRenderer->AddSourceObject('datetimepickerWithIcon', false);
 
@@ -35,7 +35,7 @@ class TCMSFieldDateTimeNow extends TCMSFieldDateTime
     {
         $fieldValue = parent::_GetHTMLValue();
         if ('' === $fieldValue || '0000-00-00 00:00:00' === $fieldValue) {
-            $fieldValue = date('Y-m-d H:i').':00'; // datetimepicker crashes if we pass seconds != "00"
+            $fieldValue = date('Y-m-d H:i:s');
         }
 
         return $fieldValue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#306
| License       | MIT

First, the TCMSFieldDateTime field with the datetimepicker() widget did mysterious things because the date field in the database had seconds and datetimepicker() by default doesn't represent seconds. After I found the country-specific date and time setting WITH seconds (format: "L LTS") for the datetimepicker() widget, I had an ugly styling error:

![selection_267](https://user-images.githubusercontent.com/26296728/52572486-35e7fe80-2e18-11e9-96dc-3380c04917bd.jpg)

Unfortunately this could not be investigated, because it immediately collapsed again when leaving the field. Even with devTools this could not be prevented.

After some searching I found the options keepOpen: true and debug: true for the datetimepicker(). This allowed me to find and overwrite the wrong css setting.
