### PR TITLE
ref #100: Display sidebar menu categories as dropdowns

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1547452866.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1547452866.inc.php
@@ -6,6 +6,8 @@
 </div>
 <?php
 
+$fieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
+
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
     ->setFields([
         'cms_tbl_conf_id' => TCMSLogChange::GetTableId('cms_tbl_conf'),
@@ -24,11 +26,11 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
         'restrict_to_groups' => '0',
         'field_width' => '0',
         'position' => '2124',
-        '049_helptext' => 'The field is used to display a font icon to the menu item of the table. Fill in the class name here, for example for Font Awesome: fas fa-check',
+        '049_helptext' => 'The field is used to display a font icon next to the menu item of the table. Fill in the class name here, for example for Font Awesome: fas fa-check',
         'row_hexcolor' => '',
         'is_translatable' => '0',
         'validation_regex' => '',
-        'id' => TCMSLogChange::createUnusedRecordId('cms_field_conf'),
+        'id' => $fieldId,
     ])
 ;
 TCMSLogChange::insert(__LINE__, $data);
@@ -37,6 +39,18 @@ $query = "ALTER TABLE `cms_tbl_conf`
                         ADD `icon_font_css_class` VARCHAR(255) NOT NULL COMMENT 'Icon Font CSS class: '";
 TCMSLogChange::RunQuery(__LINE__, $query);
 
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields([
+        'translation' => 'Icon Font CSS-Klasse',
+        '049_helptext' => 'In diesem Feld kann ein Font-Icon angegeben werden, das neben dem Menüeintrag für die Tabelle dargestellt wird. Tragen Sie hier den Klassennamen ein, z.B. für Font Awesome: fas fa-check',
+    ])
+    ->setWhereEquals([
+        'id' => $fieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$fieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
 
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
     ->setFields([
@@ -56,11 +70,11 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
         'restrict_to_groups' => '0',
         'field_width' => '0',
         'position' => '2125',
-        '049_helptext' => 'The field is used to display a font icon to the menu item of the module. Fill in the class name here, for example for Font Awesome: fas fa-check',
+        '049_helptext' => 'The field is used to display a font icon next to the menu item of the module. Fill in the class name here, for example for Font Awesome: fas fa-check',
         'row_hexcolor' => '',
         'is_translatable' => '0',
         'validation_regex' => '',
-        'id' => TCMSLogChange::createUnusedRecordId('cms_field_conf'),
+        'id' => $fieldId,
     ])
 ;
 TCMSLogChange::insert(__LINE__, $data);
@@ -69,3 +83,13 @@ $query = "ALTER TABLE `cms_module`
                         ADD `icon_font_css_class` VARCHAR(255) NOT NULL COMMENT 'Icon Font CSS class: '";
 TCMSLogChange::RunQuery(__LINE__, $query);
 
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields([
+        'translation' => 'Icon Font CSS-Klasse',
+        '049_helptext' => 'In diesem Feld kann ein Font-Icon angegeben werden, das neben dem Menüeintrag für das Modul dargestellt wird. Tragen Sie hier den Klassennamen ein, z.B. für Font Awesome: fas fa-check',
+    ])
+    ->setWhereEquals([
+        'id' => $fieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549281421.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549281421.inc.php
@@ -219,7 +219,52 @@ TCMSLogChange::update(__LINE__, $data);
 $query = 'ALTER TABLE `cms_menu_category` ADD INDEX ( `position` )';
 TCMSLogChange::RunQuery(__LINE__, $query);
 
-// Add field cms_menu_item
+// Add icon_font_css_class field.
+
+$iconFontCssClassFieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+    ->setFields([
+        'cms_tbl_conf_id' => $cmsMenuCategoryTableId,
+        'name' => 'icon_font_css_class',
+        'translation' => '',
+        'cms_field_type_id' => TCMSLogChange::GetFieldType('CMSFIELD_STRING'),
+        'cms_tbl_field_tab' => '',
+        'isrequired' => '0',
+        'fieldclass' => '',
+        'fieldclass_subtype' => '',
+        'class_type' => 'Core',
+        'modifier' => 'none',
+        'field_default_value' => '',
+        'length_set' => '',
+        'fieldtype_config' => '',
+        'restrict_to_groups' => '0',
+        'field_width' => '',
+        'position' => '0',
+        '049_helptext' => '',
+        'row_hexcolor' => '',
+        'is_translatable' => '0',
+        'validation_regex' => '',
+        'id' => $iconFontCssClassFieldId,
+    ])
+;
+TCMSLogChange::insert(__LINE__, $data);
+
+$query ="ALTER TABLE `cms_menu_category`
+                        ADD `icon_font_css_class` VARCHAR(255) NOT NULL";
+TCMSLogChange::RunQuery(__LINE__, $query);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields([
+        'translation' => 'Icon-Font CSS-Klasse',
+    ])
+    ->setWhereEquals([
+        'id' => $iconFontCssClassFieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+// Add cms_menu_item field.
 
 $cmsMenuItemFieldId = TCMSLogChange::createUnusedRecordId('cms_field_conf');
 

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549281421.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549281421.inc.php
@@ -241,7 +241,7 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
         'restrict_to_groups' => '0',
         'field_width' => '',
         'position' => '0',
-        '049_helptext' => '',
+        '049_helptext' => 'The field is used to display a font icon next to the menu item. Fill in the class name here, for example for Font Awesome: fas fa-check',
         'row_hexcolor' => '',
         'is_translatable' => '0',
         'validation_regex' => '',
@@ -257,6 +257,7 @@ TCMSLogChange::RunQuery(__LINE__, $query);
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
     ->setFields([
         'translation' => 'Icon-Font CSS-Klasse',
+        '049_helptext' => 'In diesem Feld kann ein Font-Icon angegeben werden, das neben dem Menüeintrag dargestellt wird. Tragen Sie hier den Klassennamen ein, z.B. für Font Awesome: fas fa-check',
     ])
     ->setWhereEquals([
         'id' => $iconFontCssClassFieldId,

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549299689.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549299689.inc.php
@@ -6,24 +6,24 @@
 <?php
 
 $categoryDef = <<<EOT
-contents # Contents # Inhalte
-products # Products & categories # Produkte & Kategorien
-productlists # Product lists # Produktlisten
-discounts # Discounts & vouchers # Rabatte & Gutscheine
-orders # Orders # Bestellungen
-checkout # Checkout # Checkout
-externalusers # Customers / users # Kunden / Benutzer
-ratings # Shop ratings # Shop-Bewertungen
-search # Search # Suche
-analytics # Analytics # Analyse
-communication # Communication # Kommunikation
-dataexchange # Data exchange # Datenaustausch
-layout # Layout # Layout
-internationalization # Internationalization # Internationalisierung
-internalusers # Internal users # Interne Benutzer
-logs # Logs # Logs
-routing # Routing # Routing
-system # System # System
+contents             # Contents              # Inhalte               # fas fa-file-alt
+products             # Products & categories # Produkte & Kategorien # fas fa-cubes
+productlists         # Product lists         # Produktlisten         # fas fa-boxes
+discounts            # Discounts & vouchers  # Rabatte & Gutscheine  # fas fa-gift
+orders               # Orders                # Bestellungen          # fas fa-shopping-basket
+checkout             # Checkout              # Checkout              # fas fa-truck-monster
+externalusers        # Customers / users     # Kunden / Benutzer     # fas fa-user
+ratings              # Shop ratings          # Shop-Bewertungen      # fas fa-star
+search               # Search                # Suche                 # fas fa-search
+analytics            # Analytics             # Analyse               # fas fa-chart-pie
+communication        # Communication         # Kommunikation         # fas fa-at
+dataexchange         # Data exchange         # Datenaustausch        # fas fa-exchange-alt
+layout               # Layout                # Layout                # far fa-address-card
+internationalization # Internationalization  # Internationalisierung # fas fa-flag
+internalusers        # Internal users        # Interne Benutzer      # fas fa-user-lock
+logs                 # Logs                  # Logs                  # fas fa-clipboard-list
+routing              # Routing               # Routing               # fas fa-random
+system               # System                # System                # fas fa-cog
 EOT;
 
 $categoryLines = \explode(PHP_EOL, $categoryDef);
@@ -31,7 +31,7 @@ $position = 0;
 
 foreach ($categoryLines as $categoryLine) {
     $id = TCMSLogChange::createUnusedRecordId('cms_menu_category');
-    [$systemName, $nameEn, $nameDe] = \explode(' # ', $categoryLine);
+    [$systemName, $nameEn, $nameDe, $iconFontCssClass] = \preg_split('/\s+#\s+/', $categoryLine);
 
     $data = TCMSLogChange::createMigrationQueryData('cms_menu_category', 'en')
         ->setFields([
@@ -39,6 +39,7 @@ foreach ($categoryLines as $categoryLine) {
             'name' => $nameEn,
             'position' => $position,
             'system_name' => $systemName,
+            'icon_font_css_class' => $iconFontCssClass,
         ])
     ;
     TCMSLogChange::insert(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549367836.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549367836.inc.php
@@ -202,7 +202,7 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
       'restrict_to_groups' => '0',
       'field_width' => '',
       'position' => '0',
-      '049_helptext' => '',
+      '049_helptext' => 'The field is used to display a font icon next to the menu item. Fill in the class name here, for example for Font Awesome: fas fa-check',
       'row_hexcolor' => '',
       'is_translatable' => '0',
       'validation_regex' => '',
@@ -218,6 +218,7 @@ TCMSLogChange::RunQuery(__LINE__, $query);
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
   ->setFields([
       'translation' => 'Icon Font CSS-Klasse',
+      '049_helptext' => 'In diesem Feld kann ein Font-Icon angegeben werden, das neben dem Menüeintrag dargestellt wird. Tragen Sie hier den Klassennamen ein, z.B. für Font Awesome: fas fa-check',
   ])
   ->setWhereEquals([
       'id' => $iconFontCssClassFieldId,

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549624862.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549624862.inc.php
@@ -33,7 +33,7 @@ $fieldId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('cms_tbl_con
 
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
   ->setFields([
-      '049_helptext' => 'The field is used to display a font icon to the menu item of the table. Fill in the class name here, for example for Font Awesome: fas fa-check
+      '049_helptext' => 'The field is used to display a font icon next to the menu item of the table. Fill in the class name here, for example for Font Awesome: fas fa-check
 
 @deprecated since 6.3.0 - configure CSS classes in the main menu item configuration instead.',
   ])
@@ -83,7 +83,7 @@ $fieldId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('cms_module'
 
 $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
     ->setFields([
-        '049_helptext' => 'The field is used to display a font icon to the menu item of the module. Fill in the class name here, for example for Font Awesome: fas fa-check
+        '049_helptext' => 'The field is used to display a font icon next to the menu item of the module. Fill in the class name here, for example for Font Awesome: fas fa-check
 
 @deprecated since 6.3.0 - configure CSS classes in the main menu item configuration instead.',
     ])

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
@@ -18,23 +18,34 @@ class MenuCategory
      */
     private $name;
     /**
+     * @var string
+     */
+    private $iconFontCssClass;
+    /**
      * @var MenuItem[]
      */
     private $menuItems;
 
     /**
      * @param string     $name
+     * @param string     $iconFontCssClass
      * @param MenuItem[] $menuItems
      */
-    public function __construct(string $name, array $menuItems)
+    public function __construct(string $name, string $iconFontCssClass, array $menuItems)
     {
         $this->name = $name;
+        $this->iconFontCssClass = $iconFontCssClass;
         $this->menuItems = $menuItems;
     }
 
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getIconFontCssClass(): string
+    {
+        return $this->iconFontCssClass;
     }
 
     public function getMenuItems(): array

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
@@ -128,7 +128,7 @@ class SidebarBackendModule extends \MTPkgViewRendererAbstractModuleMapper
                 }
             }
             if (\count($menuItems) > 0) {
-                $menuCategories[] = new MenuCategory($tdbCategory->fieldName, $menuItems);
+                $menuCategories[] = new MenuCategory($tdbCategory->fieldName, $tdbCategory->fieldIconFontCssClass, $menuItems);
             }
         }
 

--- a/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
+++ b/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
@@ -25,24 +25,22 @@
         filter: function (event) {
             const searchTerm = event.target.value;
             if ('' === searchTerm) {
-                this.$navTitles.removeClass('d-none');
+                this.$navTitles.removeClass('d-none open');
                 this.$navItems.removeClass('d-none');
 
                 return;
             }
             if ('undefined' === typeof this.$navItems) {
-                this.$navTitles = this.$baseElement.find('.nav-title');
-                this.$navItems = this.$baseElement.find('.nav-item');
+                this.$navTitles = this.$baseElement.find('.nav-dropdown');
+                this.$navItems = this.$baseElement.find('.nav-dropdown-items .nav-item');
             }
 
-            this.$navTitles.addClass('d-none');
+            this.$navTitles.addClass('d-none').removeClass('open');
             this.$navItems.addClass('d-none');
+
             const $matchingNavItems = this.$navItems.find(":chameleonContainsCaseInsensitive('" + searchTerm + "')").closest('.nav-item');
             $matchingNavItems.removeClass('d-none');
-            // Find title for matching nav items directly after title.
-            $matchingNavItems.prev('.nav-title').removeClass('d-none');
-            // Find title for further matching nav items.
-            $matchingNavItems.prevUntil('.nav-title').prev('.nav-title').removeClass('d-none');
+            $matchingNavItems.parents('.nav-item').addClass('open').removeClass('d-none');
         },
         onSidebarToggle: function () {
             const url = this.$baseElement.data('toggle-notification-url');

--- a/src/CoreBundle/Resources/public/themes/standard/css/global.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/global.css
@@ -409,6 +409,14 @@ div.grippie {
     color: #576873;
 }
 
+.sidebar .nav-dropdown-items .nav-item {
+    background-color: #FFFFFF;
+}
+
+.sidebar .nav-dropdown-items .nav-link {
+    color: #000000 !important;
+}
+
 /**
 Bootstrap 4 addons.
  */

--- a/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
@@ -8,14 +8,21 @@
     <nav class="sidebar-nav">
         <ul class="nav">
             {% for category in menuItems %}
-                <li class="nav-title">{{ category.name }}</li>
-                {% for menuItem in category.menuItems %}
-                    <li class="nav-item">
-                        <a href="{{ menuItem.url }}" class="nav-link">
-                            <i class="nav-icon {{ menuItem.icon|e('html_attr') }}"></i>{{ menuItem.name }}
-                        </a>
-                    </li>
-                {% endfor %}
+                <li class="nav-item nav-dropdown">
+                    <a class="nav-link nav-dropdown-toggle" href="#">
+                        <i class="nav-icon {{ category.iconFontCssClass|default('fas fa-sign-out-alt') }}"></i>
+                        {{ category.name }}
+                    </a>
+                    <ul class="nav-dropdown-items">
+                        {% for menuItem in category.menuItems %}
+                            <li class="nav-item">
+                                <a href="{{ menuItem.url }}" class="nav-link">
+                                    <i class="nav-icon {{ menuItem.icon|e('html_attr') }}"></i>{{ menuItem.name }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </li>
             {% endfor %}
         </ul>
         <div class="ps__rail-x">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#100
| License       | MIT

Displays sidebar menu items as dropdowns so that the minimized view makes more sense. This required adding icons to the menu categories.

When minimized, the items from the lower dropdowns will be cropped by the lower screen border, but I didn't spend that much time in fixing it. We can live with it for some time, and maybe someone else finds a solution :-)
