### PR TITLE
ref #100: Rework active category so it works with active cache

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/MenuCategory.php
@@ -26,10 +26,6 @@ class MenuCategory
      */
     private $iconFontCssClass;
     /**
-     * @var bool
-     */
-    private $isActive;
-    /**
      * @var MenuItem[]
      */
     private $menuItems;
@@ -38,15 +34,13 @@ class MenuCategory
      * @param string     $id
      * @param string     $name
      * @param string     $iconFontCssClass
-     * @param bool       $isActive
      * @param MenuItem[] $menuItems
      */
-    public function __construct(string $id, string $name, string $iconFontCssClass, bool $isActive, array $menuItems)
+    public function __construct(string $id, string $name, string $iconFontCssClass, array $menuItems)
     {
         $this->id = $id;
         $this->name = $name;
         $this->iconFontCssClass = $iconFontCssClass;
-        $this->isActive = $isActive;
         $this->menuItems = $menuItems;
     }
 
@@ -63,11 +57,6 @@ class MenuCategory
     public function getIconFontCssClass(): string
     {
         return $this->iconFontCssClass;
-    }
-
-    public function isActive(): bool
-    {
-        return $this->isActive;
     }
 
     public function getMenuItems(): array

--- a/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/Sidebar/SidebarBackendModule.php
@@ -68,6 +68,7 @@ class SidebarBackendModule extends \MTPkgViewRendererAbstractModuleMapper
             $value = '';
         }
         $this->responseVariableReplacer->addVariable('sidebarDisplayState', $value);
+        $this->responseVariableReplacer->addVariable('sidebarActiveCategory', \TGlobal::OutHTML($this->getActiveCategory()));
     }
 
     /**
@@ -125,8 +126,6 @@ class SidebarBackendModule extends \MTPkgViewRendererAbstractModuleMapper
             return [];
         }
 
-        $activeCategoryId = $this->getActiveCategory();
-
         $tdbCategoryList = \TdbCmsMenuCategoryList::GetList();
         $tdbCategoryList->ChangeOrderBy([
             '`cms_menu_category`.`position`' => 'ASC',
@@ -150,7 +149,6 @@ class SidebarBackendModule extends \MTPkgViewRendererAbstractModuleMapper
                     $tdbCategory->id,
                     $tdbCategory->fieldName,
                     $tdbCategory->fieldIconFontCssClass,
-                    $activeCategoryId === $tdbCategory->id,
                     $menuItems
                 );
             }

--- a/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
+++ b/src/CoreBundle/Resources/public/javascript/modules/sidebar/sidebar.js
@@ -17,6 +17,8 @@
             sidebarMinimizerElement.on('click', self.onSidebarToggle.bind(this));
             this.$baseElement.find('.nav-dropdown-toggle').on('click', self.onCategoryToggle.bind(this));
 
+            this.$baseElement.find('[data-categoryid="' + this.$baseElement.data('active-category') + '"]').addClass('open');
+
             $.extend($.expr[':'], {
                 'chameleonContainsCaseInsensitive': function(elem, i, match, array) {
                     return (elem.textContent || elem.innerText || '').toLowerCase().indexOf((match[3] || "").toLowerCase()) >= 0;

--- a/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/BackendSidebar/standard.html.twig
@@ -2,6 +2,7 @@
         class="sidebar"
         data-toggle-notification-url="{{ sidebarToggleNotificationUrl|e('html_attr') }}"
         data-save-active-category-notification-url="{{ sidebarSaveActiveCategoryNotificationUrl|e('html_attr') }}"
+        data-active-category="[{sidebarActiveCategory}]"
 >
     <p class="sidebar-filter-input-wrapper fas"><input
             type="text"
@@ -12,7 +13,7 @@
     <nav class="sidebar-nav">
         <ul class="nav">
             {% for category in menuItems %}
-                <li class="nav-item nav-dropdown {% if category.active %}open{% endif %}" data-categoryid="{{ category.id }}">
+                <li class="nav-item nav-dropdown" data-categoryid="{{ category.id }}">
                     <a class="nav-link nav-dropdown-toggle" href="#">
                         <i class="nav-icon {{ category.iconFontCssClass|default('fas fa-sign-out-alt') }}"></i>
                         {{ category.name }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#100
| License       | MIT

On the previous solution for restoring the active category I didn't consider the cache. This new solution now adds a post-render variable for the active category and uses it on the client side.