### PR TITLE
ref #204: correct date format in JS after format has changed to "L" or "L LTS"

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -770,10 +770,10 @@ CHAMELEON.CORE.MTTableEditor.initDateTimePickers  = function () {
                 return;
             }
 
-            if ($(this).hasClass('format-L')) {
-                var cmsDate = moment.format('YYYY-MM-DD');
-            } else {
+            if ($(this).hasClass('format-L') && $(this).hasClass('LTS')) {
                 var cmsDate = moment.format('YYYY-MM-DD HH:mm:ss');
+            } else {
+                var cmsDate = moment.format('YYYY-MM-DD');
             }
             // We need a SQL date format for BC reasons.
             $('input[name=' + id + ']').val(cmsDate);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#204
| License       | MIT

datetimepicker plugin:
With commit "ref #306: TCMSFieldDateTime with seconds" the format has changed from "" to "L LTS". This was not considered in the corresponding tableEditor.js yet and led to the error.

