### PR TITLE
ref #328: fix check for open modal dialog

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/cms.js
+++ b/src/CoreBundle/Resources/public/javascript/cms.js
@@ -413,7 +413,7 @@ CHAMELEON.CORE.handleFormAndLinkTargetsInModals = function () {
         return;
     }
 
-    if (false === $('#modal_dialog', top.document).dialog('isOpen')) {
+    if (0 === $('#modal_dialog', top.document).length) {
         return;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#328
| License       | MIT

While testing, i found out, that the check for the existence of the jquery UI modal was wrong.
Fixed it.