### PR TITLE
ref #294: mediaManager: change checkbox styling

### DIFF
--- a/src/MediaManagerBundle/Resources/views/snippets-cms/mediaManager/list/listHeader.html.twig
+++ b/src/MediaManagerBundle/Resources/views/snippets-cms/mediaManager/list/listHeader.html.twig
@@ -17,7 +17,7 @@
             <div class="row">
                 <div class="col-12 col-lg-6">
                     <div class="d-flex align-items-center">
-                        <label class="switch switch-sm switch-label switch-pill switch-success mb-0 mr-2">
+                        <label class="switch switch-sm switch-label switch-success mb-0 mr-2">
                             <input type="checkbox" class="switch-input show-subtree" {% if listState.showSubtree == '1' %} checked{% endif %}>
                             <span class="switch-slider" data-checked="✓" data-unchecked="✕"></span>
                         </label>
@@ -27,7 +27,7 @@
                     </div>
                     {% if accessRightsMedia.delete %}
                         <div class="d-flex align-items-center mt-1">
-                            <label class="switch switch-sm switch-label switch-pill switch-success mb-0 mr-2">
+                            <label class="switch switch-sm switch-label switch-success mb-0 mr-2">
                                 <input type="checkbox" class="switch-input delete-with-usage-search"{% if listState.deleteWithUsageSearch == '1' %} checked{% endif %}>
                                 <span class="switch-slider" data-checked="✓" data-unchecked="✕"></span>
                             </label>

--- a/src/MediaManagerBundle/Resources/views/snippets-cms/mediaManager/list/listList.html.twig
+++ b/src/MediaManagerBundle/Resources/views/snippets-cms/mediaManager/list/listList.html.twig
@@ -28,11 +28,8 @@
     {% for mediaItem in mediaItems %}
         {# mediaItem \ChameleonSystem\MediaManager\DataModel\MediaItemDataModel #}
         <div class="row pt-2 pb-2 cms-media-item" data-id="{{ mediaItem.id }}" data-name="{{ mediaItem.name }}">
-            <div class="col-2 col-md-1 selection-box">
-                <label class="switch switch-sm switch-label switch-pill switch-secondary">
-                    <input class="switch-input select-row" type="checkbox">
-                    <span class="switch-slider" data-checked="✓" data-unchecked="✕"></span>
-                </label>
+            <div class="col-2 col-md-1 selection-box align-self-center">
+                <input class="select-row" type="checkbox">
             </div>
             <div class="col-10 col-md-11">
                 <div class="row">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#294   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The styling of the checkboxes has changed:
![Selection_305](https://user-images.githubusercontent.com/26296728/54188005-18f22a00-44af-11e9-91d4-8d8f16624fa7.jpg)

