### PR TITLE
ref #346: Use frontend router for URL generation so that the domain i…

### DIFF
--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -328,6 +328,7 @@
             <argument type="service" id="chameleon_system_core.service_initializer.active_page_service" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="router" />
+            <argument type="service" id="chameleon_system_core.router.chameleon_frontend" />
             <argument type="service" id="chameleon_system_core.util.url" />
             <argument type="service" id="chameleon_system_core.request_info_service" />
             <argument type="service" id="chameleon_system_core.util.routing"/>


### PR DESCRIPTION
…s set correctly

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#346
| License       | MIT

This fixes the case when there are multiple domains for a portal while every domain has a fixed language. The case that there is one domain without language setting isn't handled yet - this requires talking about if this should still be supported first.