### PR TITLE
ref #92: Improve upgrade guide; add deprecations; fix cronjob channel…

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -47,33 +47,97 @@ not expected.
 
 ## Logging
 
-We are now using standard logging for Symfony applications using `Monolog` and `Psr\Log\LoggerInterface`.
-Desired differences in logging - like different log files - should be configured using Monolog or implemented using
-its interfaces (like `HandlerInterface`, `ProcessorInterface`, ...).
+Chameleon now logs messages similar to other Symfony applications, using `Psr\Log\LoggerInterface` and `Monolog`.
 
-This is already done in most places in Chameleon itself (chameleon-base and chameleon-shop).
+### Logging Configuration
 
-Project code should also be adapted to this. See below for a migration example.
-Note that if there is no handler configuration in your project nothing will be written.
-A minimum config could be a stream handler logging to `%kernel.logs_dir%/%kernel.environment%.log`.
+We recommend using the standard Symfony logging configuration as a base point from where to adjust to project needs.
+The application will then log to the logs dir (`app/logs/` by default).
 
-Note that log messages are no longer written to database.
-You can still configure this if needed with the service `cmsPkgCore.logHandler.database` (TPkgCmsCoreLogMonologHandler_Database).
-If you use this without channel restriction you must at least explicitly exclude the channel "doctrine".
-Also note that the standard logging channel is not configured as "fingerscrossed" anymore. All messages there will simply
-be logged everytime.
-See below for the full legacy config.
+Add the following lines to `app/config/config_dev.yml`:
 
-However deprecated service definitions for the old log (channel) handler classes still exist in 
-`vendor/chameleon-system/chameleon-base/src/CmsCoreLogBundle/Resources/config/services.xml`.
-These will be removed in a later release.
+```yaml
+monolog:
+  handlers:
+    main:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+      channels: ["!event"]
+    # uncomment to get logging in your browser
+    # you may have to allow bigger header sizes in your Web server configuration
+    #firephp:
+    #    type: firephp
+    #    level: info
+    #chromephp:
+    #    type: chromephp
+    #    level: info
+    console:
+      type: console
+      process_psr_3_messages: false
+      channels: ["!event", "!doctrine", "!console"]
+```
 
-The menu entries in the backend ("logs", "log channel definition") are now hidden - that is: they are no longer 
-assigned to the category window ("Logs"). To show them again you can assign them again.
+Add the following lines to `app/config/config_prod.yml`:
 
-Migration example for changing/defining a log handler for a channel logging to a file:
+```yaml
+monolog:
+  handlers:
+    main:
+      type: fingers_crossed
+      action_level: error
+      handler: nested
+      excluded_404s:
+        # regex: exclude all 404 errors from the logs
+        - ^/
+    nested:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+    console:
+      type: console
+      process_psr_3_messages: false
+      channels: ["!event", "!doctrine"]
+    deprecation:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+    deprecation_filter:
+      type: filter
+      handler: deprecation
+      max_level: info
+      channels: ["php"]
+```
 
-Old in service.xml:
+Add the following lines to `app/config/config_test.yml`:
+
+```yaml
+monolog:
+  handlers:
+    main:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+      channels: ["!event"]
+```
+
+See the Monolog documentation on how to change logging behaviour, e.g. logging to different files or modifying log
+entries with formatters and processors.
+
+### Adjust Logger Retrieval
+
+There is a number of classes and methods which were used for logging in previous Chameleon releases (and still work)
+but are now deprecated, especially `IPkgCmsCoreLog`, `TPkgCmsCoreLog`, `TTools::WriteLogEntry` and 
+`TTools::WriteLogEntrySimple`. It is recommended to switch to standard logging as soon as possible. Do this as follows:
+- Where dependency injection is possible, inject the `logger` service and typehint `Psr\Log\LoggerInterface`.
+- To use a specific channel, add a tag like this: `<tag name="monolog.logger" channel="order_payment_amazon"/>`
+- Where dependency injection cannot be used, retrieve the logger by service locator like this: `ChameleonSystem\CoreBundle\ServiceLocator::get('logger')`.
+  The return value can always be typehinted with `Psr\Log\LoggerInterface`.
+- To retrieve a specific log channel, use a call like this: `ChameleonSystem\CoreBundle\ServiceLocator::get('monolog.logger.custom_channel')`.
+
+Migration example:
+
+Old in services.xml (logger writing to a file):
+
 ```xml
 <service id="cmsPkgCore.logHandler.files" class="Monolog\Handler\StreamHandler" public="false">
     <argument>%kernel.logs_dir%/core.log</argument>
@@ -90,29 +154,31 @@ Old in service.xml:
 <service id="cmsPkgCore.logChannel.cmsUpdates" class="TPkgCmsCoreLog">
     <argument type="service" id="monolog.logger.cms_update"/>
 </service>
+
+<service id="myService" class="MyClass">
+    <argument type="service" id="cmsPkgCore.logChannel.cmsUpdates" />
+</service>
+
 ```
 
-New in config.yml - changed the channel name slightly:
-```
-monolog:
-   handlers:
-       cms_updates:
-           type: stream
-           path: "%kernel.logs_dir%/core.log"
-           channels:
-               - "cms_update"
-           level: info
-```
+New in services.xml:
 
-This is then used in that service.xml as two service arguments instead of a reference to `cmsPkgCore.logChannel.cmsUpdates`:
-```
+```xml
+<service id="myService" class="MyClass">
     <argument type="service" id="logger"/>
-    <tag name="monolog.logger" channel="cms_updates"/>
+    <tag name="monolog.logger" channel="cms_update"/>
+</service>
 ```
 
-The full config (in config.yml) that would replicate the legacy logging behavior of Chameleon 6.2 looks like this:
+So the service definition just states the channel in which to log. Directing log output to e.g. a file is then handled
+in the logging configuration in `config_<env>.yml`.
 
-```
+### Legacy: Restore Database Logging
+
+Log messages are no longer written to database and the old database logging infrastructure will be removed in
+a future Chameleon release. If database logging is still needed in the project, restore by using the following config:
+
+```yaml
 monolog:
    handlers:
      database:
@@ -141,6 +207,14 @@ monolog:
          - "doctrine"
        level: warning
 ```
+
+Note that the `doctrine` channel MUST be excluded from database logging.
+Also note that the standard logging channel is not configured as "fingerscrossed" anymore. All messages for this channel
+will simply be logged on every request.
+
+Log-related menu items in the backend ("logs", "log channel definition") are now hidden. To display these items in the
+new sidebar menu, create menu items assigned to the corresponding tables. To display these items in the classic main
+menu (which itself is no longer visible by default), assign the tables to the "Logs" content box.
 
 ## New ImageCropBundle
 
@@ -174,6 +248,16 @@ Using this setting SMTP connections verify SSL/TLS certificate validity so that 
 We now use the DoctrineBundle. While we do not use many of its features yet (especially no ORM mapping), initializing
 the database connection is now handled by Doctrine. In practice the most noticeable difference is that the connection
 is opened lazily, so that more console commands can be executed without a working database connection.
+
+Add the DoctrineBundle to the AppKernel:
+
+```php
+    $bundles = array(
+    ...
+    new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+    ...
+    );
+```
 
 This change requires to add the following configuration to `/app/config/config.yml`:
 
@@ -433,6 +517,7 @@ is recommended (although this tool may not find database-related deprecations).
 
 ## Services
 
+- chameleon_system_cms_core_log.cronjob.cleanup_cronjob
 - chameleon_system_core.pdo
 - cmsPkgCore.logChannel.apilogger
 - cmsPkgCore.logChannel.cmsUpdates
@@ -446,6 +531,7 @@ is recommended (although this tool may not find database-related deprecations).
 - cmsPkgCore.logDriver.dbal
 - cmsPkgCore.logDriver.security
 - cmsPkgCore.logDriver.standard
+- cmsPkgCore.logHandler.database
 - cmsPkgCore.logHandler.dbal
 - cmsPkgCore.logHandler.files
 - cmsPkgCore.logHandler.fingerscrossed
@@ -474,6 +560,8 @@ is recommended (although this tool may not find database-related deprecations).
 - \CMS_ACTIVE_REVISION_MANAGEMENT
 - \PATH_FILETYPE_ICONS
 - \PATH_FILETYPE_ICONS_LOW_QUALITY
+- \PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS
+- \PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS_LEVEL_BELOW_WARNING
 - \TCMSCronJob_CleanOrphanedMLTConnections::MLT_DELETE_LOG_FILE
 - \TCMSTableEditorEndPoint::DELETE_REFERENCES_REVISION_DATA_WHITELIST_SESSION_VAR
 - \TPkgCsv2SqlManager::IMPORT_ERROR_LOG_FILE
@@ -482,6 +570,8 @@ is recommended (although this tool may not find database-related deprecations).
 
 ## Classes and Interfaces
 
+- \ChameleonSystem\CmsCoreLogBundle\Bridge\Chameleon\ListManager\TCMSListManagerLogEntries
+- \ChameleonSystem\CmsCoreLogBundle\Command\LogShowCommand
 - \IPkgCmsCoreLog
 - \MTMenuManager
 - \TCMSContentBox
@@ -495,6 +585,8 @@ is recommended (although this tool may not find database-related deprecations).
 - \TCMSMenuItem_Table
 - \THTMLFileBrowser
 - \TPkgCmsCoreLog
+- \TPkgCmsCoreLogCleanupCronJob
+- \TPkgCmsCoreLogMonologHandler_Database
 - \TPkgSnippetRenderer_TranslationNode
 - \TPkgSnippetRenderer_TranslationTokenParser
 - \TTemplateTools
@@ -627,6 +719,10 @@ that are deprecated because they are outdated and replaced by frontend themes or
 - chameleon_system_core.record_revision.no_revision_exists
 - chameleon_system_core.record_revision.revision_number
 - chameleon_system_core.template_engine.header_revision
+- pkg_cms_core_log.log_table.field_level
+- pkg_cms_core_log.log_table.select_level_all
+- pkg_cms_core_log.log_table.select_level_all_errors
+- pkg_cms_core_log.log_table.select_level_only
 
 ## Database Tables
 

--- a/src/CmsCoreLogBundle/Bridge/Chameleon/ListManager/TCMSListManagerLogEntries.php
+++ b/src/CmsCoreLogBundle/Bridge/Chameleon/ListManager/TCMSListManagerLogEntries.php
@@ -18,6 +18,9 @@ use Monolog\Logger;
 use TCMSListManagerFullGroupTable;
 use ViewRenderer;
 
+/**
+ * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+ */
 class TCMSListManagerLogEntries extends TCMSListManagerFullGroupTable
 {
     const ALL_SELECTION_VALUE = '0';

--- a/src/CmsCoreLogBundle/Command/LogShowCommand.php
+++ b/src/CmsCoreLogBundle/Command/LogShowCommand.php
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+ */
 class LogShowCommand extends Command
 {
     protected function configure()

--- a/src/CmsCoreLogBundle/Resources/config/services.xml
+++ b/src/CmsCoreLogBundle/Resources/config/services.xml
@@ -5,6 +5,7 @@
 
     <services>
         <service id="chameleon_system_cms_core_log.cronjob.cleanup_cronjob" class="TPkgCmsCoreLogCleanupCronJob" shared="false">
+            <deprecated>The "%service_id%" service is deprecated since Chameleon 6.3.</deprecated>
             <tag name="chameleon_system.cronjob" />
         </service>
 
@@ -13,6 +14,7 @@
         </service>
 
         <service id="cmsPkgCore.logHandler.database" class="TPkgCmsCoreLogMonologHandler_Database" public="false">
+            <deprecated>The "%service_id%" service is deprecated since Chameleon 6.3.</deprecated>
             <argument type="service" id="database_connection"/>
         </service>
 

--- a/src/CmsCoreLogBundle/Resources/translations/admin.de.xliff
+++ b/src/CmsCoreLogBundle/Resources/translations/admin.de.xliff
@@ -5,18 +5,22 @@
             <trans-unit id="pkg_cms_core_log.log_table.field_level">
                 <source>pkg_cms_core_log.log_table.field_level</source>
                 <target>Loglevel</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_all">
                 <source>pkg_cms_core_log.log_table.select_level_all</source>
                 <target>Alle</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_all_errors">
                 <source>pkg_cms_core_log.log_table.select_level_all_errors</source>
                 <target>Alle Fehler/Warnungen</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_only">
                 <source>pkg_cms_core_log.log_table.select_level_only</source>
                 <target>Nur</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
         </body>
     </file>

--- a/src/CmsCoreLogBundle/Resources/translations/admin.en.xliff
+++ b/src/CmsCoreLogBundle/Resources/translations/admin.en.xliff
@@ -5,18 +5,22 @@
             <trans-unit id="pkg_cms_core_log.log_table.field_level">
                 <source>pkg_cms_core_log.log_table.field_level</source>
                 <target>Log level</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_all">
                 <source>pkg_cms_core_log.log_table.select_level_all</source>
                 <target>All</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_all_errors">
                 <source>pkg_cms_core_log.log_table.select_level_all_errors</source>
                 <target>All errors/warnings</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
             <trans-unit id="pkg_cms_core_log.log_table.select_level_only">
                 <source>pkg_cms_core_log.log_table.select_level_only</source>
                 <target>Only</target>
+                <note>@deprecated since 6.3.0 - only used in deprecated database logging.</note>
             </trans-unit>
          </body>
     </file>

--- a/src/CmsCoreLogBundle/monolog/TPkgCmsCoreLogMonologHandler_Database.class.php
+++ b/src/CmsCoreLogBundle/monolog/TPkgCmsCoreLogMonologHandler_Database.class.php
@@ -13,6 +13,9 @@ use Doctrine\DBAL\Connection;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 
+/**
+ * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+ */
 class TPkgCmsCoreLogMonologHandler_Database extends AbstractProcessingHandler
 {
     /**

--- a/src/CmsCoreLogBundle/objects/CronJobs/TPkgCmsCoreLogCleanupCronJob.class.php
+++ b/src/CmsCoreLogBundle/objects/CronJobs/TPkgCmsCoreLogCleanupCronJob.class.php
@@ -10,12 +10,21 @@
  */
 
 if (!defined('PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS')) {
+    /**
+     * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+     */
     define('PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS', 2592000);
 }
 if (!defined('PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS_LEVEL_BELOW_WARNING')) {
+    /**
+     * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+     */
     define('PKG_CMS_CORE_LOG_DEFAULT_MAX_AGE_IN_SECONDS_LEVEL_BELOW_WARNING', 604800); // default to 7 days for notice and below
 }
 
+/**
+ * @deprecated since 6.3.0 - use Psr\Log\LoggerInterface in conjunction with Monolog logging instead
+ */
 class TPkgCmsCoreLogCleanupCronJob extends TdbCmsCronjobs
 {
     protected function _ExecuteCron()

--- a/src/CoreBundle/private/modules/CMSRunCrons/CMSRunCrons.class.php
+++ b/src/CoreBundle/private/modules/CMSRunCrons/CMSRunCrons.class.php
@@ -162,7 +162,7 @@ class CMSRunCrons extends TModelBase
 
     private function getLogger(): LoggerInterface
     {
-        return ServiceLocator::get('monolog.logger.cms_cronjob');
+        return ServiceLocator::get('monolog.logger.cronjob');
     }
 
     private function getTranslator(): TranslatorInterface


### PR DESCRIPTION
… name

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#92
| License       | MIT

Changed the upgrade guide, because I think the developer needs some more step-by-step guidance. The proposed logging config is taken straight from the Symfony default.

Added some deprecations as I think the complete database-related logging should be removed in a future releasee - let me know if you dissent.

And there was one misnamed log channel that led to a crash during cronjob exeuction.