### PR TITLE
ref #359: Use standard page path generation so that special cases are…

### DIFF
--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -333,6 +333,7 @@
             <argument type="service" id="chameleon_system_core.request_info_service" />
             <argument type="service" id="chameleon_system_core.util.routing"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="chameleon_system_core.util.page_service_util"/>
         </service>
 
         <service id="chameleon_system_core.service_initializer.active_page_service" class="ChameleonSystem\CoreBundle\Service\Initializer\ActivePageServiceInitializer" public="false">

--- a/src/CoreBundle/Service/ActivePageService.php
+++ b/src/CoreBundle/Service/ActivePageService.php
@@ -15,6 +15,7 @@ use ChameleonSystem\CoreBundle\CoreEvents;
 use ChameleonSystem\CoreBundle\Event\ChangeActivePageEvent;
 use ChameleonSystem\CoreBundle\Routing\PortalAndLanguageAwareRouterInterface;
 use ChameleonSystem\CoreBundle\Service\Initializer\ActivePageServiceInitializerInterface;
+use ChameleonSystem\CoreBundle\Util\PageServiceUtilInterface;
 use ChameleonSystem\CoreBundle\Util\RoutingUtilInterface;
 use ChameleonSystem\CoreBundle\Util\UrlUtil;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -67,8 +68,12 @@ class ActivePageService implements ActivePageServiceInterface
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+    /**
+     * @var PageServiceUtilInterface
+     */
+    private $pageServiceUtil;
 
-    public function __construct(LanguageServiceInterface $languageService, ActivePageServiceInitializerInterface $activePageServiceInitializer, RequestStack $requestStack, RouterInterface $defaultRouter, PortalAndLanguageAwareRouterInterface $frontendRouter, UrlUtil $urlUtil, RequestInfoServiceInterface $requestInfoService, RoutingUtilInterface $routingUtil, EventDispatcherInterface $eventDispatcher)
+    public function __construct(LanguageServiceInterface $languageService, ActivePageServiceInitializerInterface $activePageServiceInitializer, RequestStack $requestStack, RouterInterface $defaultRouter, PortalAndLanguageAwareRouterInterface $frontendRouter, UrlUtil $urlUtil, RequestInfoServiceInterface $requestInfoService, RoutingUtilInterface $routingUtil, EventDispatcherInterface $eventDispatcher, PageServiceUtilInterface $pageServiceUtil)
     {
         $this->languageService = $languageService;
         $this->activePageServiceInitializer = $activePageServiceInitializer;
@@ -79,6 +84,7 @@ class ActivePageService implements ActivePageServiceInterface
         $this->requestInfoService = $requestInfoService;
         $this->routingUtil = $routingUtil;
         $this->eventDispatcher = $eventDispatcher;
+        $this->pageServiceUtil = $pageServiceUtil;
     }
 
     /**
@@ -252,8 +258,11 @@ class ActivePageService implements ActivePageServiceInterface
             if ($activePage->fieldPrimaryTreeIdHidden === $activePortal->fieldHomeNodeId) {
                 unset($parameters['pagePath']);
             } else {
-                $allPageRoutes = $this->routingUtil->getAllPageRoutes($activePortal, $language);
-                $parameters['pagePath'] = rtrim($allPageRoutes[$activePage->id]->getPrimaryPath(), '/');
+                $pagePath = $this->pageServiceUtil->getPagePath($activePage, $language);
+                if (true === $activePortal->fieldUseSlashInSeoUrls) {
+                    $pagePath .= '/';
+                }
+                $parameters['pagePath'] = $pagePath;
             }
         }
     }

--- a/src/CoreBundle/Service/PageService.php
+++ b/src/CoreBundle/Service/PageService.php
@@ -57,16 +57,6 @@ class PageService implements PageServiceInterface
      */
     private $urlUtil;
 
-    /**
-     * @param PortalAndLanguageAwareRouterInterface $router
-     * @param DataAccessInterface                   $dataAccess
-     * @param TreeNodeServiceInterface              $treeNodeService
-     * @param LanguageServiceInterface              $languageService
-     * @param PortalDomainServiceInterface          $portalDomainService
-     * @param PageServiceUtilInterface              $pageServiceUtil
-     * @param RequestStack                          $requestStack
-     * @param UrlUtil                               $urlUtil
-     */
     public function __construct(PortalAndLanguageAwareRouterInterface $router, DataAccessInterface $dataAccess, TreeNodeServiceInterface $treeNodeService, LanguageServiceInterface $languageService, PortalDomainServiceInterface $portalDomainService, PageServiceUtilInterface $pageServiceUtil, RequestStack $requestStack, UrlUtil $urlUtil)
     {
         $this->router = $router;

--- a/src/CoreBundle/Util/RoutingUtil.php
+++ b/src/CoreBundle/Util/RoutingUtil.php
@@ -225,12 +225,12 @@ class RoutingUtil implements RoutingUtilInterface
             return '/';
         }
         $normalizedPagePath = $path;
-        $normalizedPagePath = rtrim($normalizedPagePath, '/');
-        if ('.html' === mb_strtolower(mb_substr($normalizedPagePath, -5))) {
-            $normalizedPagePath = mb_substr($normalizedPagePath, 0, -5);
+        $normalizedPagePath = \rtrim($normalizedPagePath, '/');
+        if ('.html' === mb_strtolower(\mb_substr($normalizedPagePath, -5))) {
+            $normalizedPagePath = \mb_substr($normalizedPagePath, 0, -5);
         }
         if (CHAMELEON_SEO_URL_REWRITE_TO_LOWERCASE) {
-            $normalizedPagePath = strtolower($path);
+            $normalizedPagePath = \strtolower($normalizedPagePath);
         }
 
         return $normalizedPagePath;


### PR DESCRIPTION
… handled; fix path lowercasing

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#359
| License       | MIT

The most important part of the fix is to use the PageServiceUtil to generate the page path. Otherwise special cases like the ".html" suffix is not taken into account correctly.

I'm not sure why we removed the trailing slash before though. Adding it instead seems to to be what we want here.

Fixed URL lowercasing in addition.