### PR TITLE
ref #99: TFullGroupTable scrollable and pagination responsive

### DIFF
--- a/src/CoreBundle/Resources/public/themes/standard/css/table.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/table.css
@@ -131,6 +131,9 @@
 
 .TCMSListManagerFullGroupTable {
     margin-bottom: 0px;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
 }
 
 .table-function-bar ul {

--- a/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
@@ -716,10 +716,10 @@ class TFullGroupTable extends TGroupTable
             document.'.$this->listName.'.submit();
         }
         </script>
-        <div class="d-flex justify-content-between">';
+        <div class="d-flex justify-content-between flex-wrap">';
         $tableNavigation .= '<nav>';
-        $tableNavigation .= '<ul class="pagination pagination-md TFullGroupTablePagination">';
-        $tableNavigation .= '<li class="disabled page-item"><a href="#" class="page-link"><span class="fas fa-list-ul" aria-hidden="true" style="margin-right: 5px;"></span>'.$hitText.'</a></li>';
+        $tableNavigation .= '<ul class="pagination pagination-md TFullGroupTablePagination flex-wrap">';
+        $tableNavigation .= '<li class="disabled page-item"><a href="#" class="page-link"><i class="fas fa-list-ul d-none d-lg-inline pr-2"></i>'.$hitText.'</a></li>';
 
         if ($this->startRecord > 0 && -1 != $this->showRecordCount) {
             $tableNavigation .= '<li class="page-item"><a href="javascript:switchPage(\'0\');" class="page-link"><i class="fas fa-fast-backward" aria-hidden="true"></i></a></li>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#99
| License       | MIT

Tables with records lists (TFullGroupTable) are now scrollable and the pagination is responsive:

![Selection_306](https://user-images.githubusercontent.com/26296728/54526524-59521c00-4977-11e9-80a9-d914d370a143.jpg)
