### PR TITLE
Feature/294 media manager iframe with flex content height

### DIFF
--- a/src/ImageCropBundle/Resources/public/css/imageCropEditor.css
+++ b/src/ImageCropBundle/Resources/public/css/imageCropEditor.css
@@ -34,11 +34,6 @@
     background: rgb(179, 232, 255);
 }
 
-.snippetImageCropImageCropEditorImageCropEditorForm {
-    margin-bottom: 20px;
-    margin-top: 10px;
-}
-
 .snippetImageCropImageCropEditorImageCropEditorForm input.crop-name {
     width: 200px;
 }

--- a/src/ImageCropBundle/Resources/views/snippets-cms/imageCrop/imageCropEditor/imageCropEditor.html.twig
+++ b/src/ImageCropBundle/Resources/views/snippets-cms/imageCrop/imageCropEditor/imageCropEditor.html.twig
@@ -2,7 +2,7 @@
 {# existingCrop \ChameleonSystem\ImageCrop\DataModel\ImageCropDataModel #}
 {# preset \ChameleonSystem\ImageCrop\DataModel\ImageCropPresetDataModel #}
 <form action="{{ formAction | e('html_attr') }}" method="post"
-      class="snippetImageCropImageCropEditorImageCropEditorForm">
+      class="snippetImageCropImageCropEditorImageCropEditorForm mb-4">
 
     {% for urlParameterKey, urlParameterValue in urlParameters %}
         <input type="hidden" name="{{ urlParameterKey | e('html_attr') }}"
@@ -22,18 +22,20 @@
     <input type="hidden" name="width" id="width" value="">
     <input type="hidden" name="height" id="height" value="">
 
-    <input type="text" name="name" value="{{ existingCrop.name }}" class="form-control crop-name"
-           placeholder="{{ 'chameleon_system_image_crop.editor.crop_name_placeholder' | trans }}"{% if not aspectRatio %} required{% endif %}>
+    <div class="d-flex flex-wrap">
+        <input type="text" name="name" value="{{ existingCrop.name }}" class="form-control mr-2 mt-2 crop-name"
+               placeholder="{{ 'chameleon_system_image_crop.editor.crop_name_placeholder' | trans }}"{% if not aspectRatio %} required{% endif %}>
 
-    <button type="submit" class="btn btn-success">
-        <span class="fas fa-save"></span> {{ 'chameleon_system_image_crop.editor.save' | trans }}
-    </button>
-
-    {% if enableCallback and existingCrop.id %}
-        <button type="submit" class="btn btn-default">
-            <span class="fas fa-expand"></span> {{ 'chameleon_system_image_crop.editor.select' | trans }}
+        <button type="submit" class="btn btn-success mr-2 mt-2">
+            <span class="fas fa-save"></span> {{ 'chameleon_system_image_crop.editor.save' | trans }}
         </button>
-    {% endif %}
+
+        {% if enableCallback and existingCrop.id %}
+            <button type="submit" class="btn btn-default mt-2">
+                <span class="fas fa-expand"></span> {{ 'chameleon_system_image_crop.editor.select' | trans }}
+            </button>
+        {% endif %}
+    </div>
 
 </form>
 

--- a/src/MediaManagerBundle/Resources/public/js/mediaManager.js
+++ b/src/MediaManagerBundle/Resources/public/js/mediaManager.js
@@ -1013,17 +1013,19 @@
 
             self.showWaitingAnimation();
 
-            var iframe = $('<iframe src="' + url + '"></iframe>');
-
             var layover = self.openLayover(title, '');
+            var iframe;
 
             if (typeof height === 'undefined') {
-                height = $('#edit-container').height() - (layover.find('.title').height() - 50);
+                iframe = $('<iframe src="' + url + '" scrolling="no" frameborder="0" onload="this.style.height=(this.contentDocument.body.scrollHeight) +\'px\';"></iframe>');
+                iframe.css({'width': '100%', 'border': 'none'});
+            } else {
+                iframe = $('<iframe src="' + url + '"></iframe>');
+                iframe.css({'width': '100%', 'height': height});
             }
-            iframe.css({'width': '100%', 'height': height}).appendTo(layover);
+            iframe.appendTo(layover);
 
             self.hideWaitingAnimation();
-
             return iframe;
         },
         openLayover: function (title, html) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#294   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The iframe for the cutout (inside the mediaManager) always had the height of its container, but the image was usually larger and the iframe had scrollbars.
Now the iframe gets its own height.

In addition, there was a styling adjustment for the save button.