### PR TITLE
ref #361: Fix main menu migration

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -265,12 +265,6 @@ Sidebar menu items are (in contrast to the classic main menu) created independen
 After migration menu items for backend modules might not yet be migrated to new sidebar menu items. Check the backend
 module list to see if modules are missing. 
 
-All menu items from standard content boxes will be migrated automatically. Custom content boxes need to be migrated
-manually. Use the method `migrateTableMenuItemsByOldContentBoxSystemName` of service
-`chameleon_system_core.service.main_menu_migrator`.
-
-Menu categories can also be moved by calling the new method `TCMSLogChange::setMainMenuPosition`.
-
 ## New ImageCropBundle
 
 Chameleon now ships with a bundle that provides support for image cutouts. Install it as follows (this is required if
@@ -663,6 +657,7 @@ Three newly defined log channels are deprecated and only necessary for backwards
 - \TCMSDownloadFileEndPoint::GetDownloadLink()
 - \TCMSFieldColorPicker::isFirstInstance()
 - \TCMSFieldLookup::enableComboBox()
+- \TCMSLogChange::getCmsContentBoxIdFromSystemName()
 - \TCMSLogChange::getUpdateLogger()
 - \TCMSTreeNode::GetPageTreeConnectionDateInformationHTML()
 - \TGlobal::GetURLHistory()

--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -263,7 +263,25 @@ menu (which itself is no longer visible by default), assign the tables to the "L
 
 Sidebar menu items are (in contrast to the classic main menu) created independently from tables and backend modules.
 After migration menu items for backend modules might not yet be migrated to new sidebar menu items. Check the backend
-module list to see if modules are missing. 
+module list to see if modules are missing.
+
+If you maintain a third-party bundle that adds new tables, there should be an additional migration script that
+migrates the menu items. This ensures that the bundle can be installed seamlessly even after the project was migrated
+to Chameleon 6.3. The migration script should contain lines as follows:
+
+```php
+TCMSLogChange::requireBundleUpdates('ChameleonSystemCoreBundle', 1549624862);
+
+/**
+ * @var ChameleonSystem\CoreBundle\Bridge\Chameleon\Migration\Service\MainMenuMigrator $mainMenuMigrator
+ */
+$mainMenuMigrator = \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.service.main_menu_migrator');
+// Add the following line if the bundle adds at least one table in a standard content box 
+$mainMenuMigrator->migrateUnhandledTableMenuItems();
+// Add the following line if the bundle adds at least one custom content box. Adjust the system name accordingly 
+$mainMenuMigrator->migrateContentBox('content_box_system_name');
+
+```
 
 ## New ImageCropBundle
 

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549541799.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1549541799.inc.php
@@ -112,6 +112,7 @@ base t pkg_cms_theme_block                   layout
 base t cms_message_manager_message_type      layout
 shop t shop_variant_display_handler          layout
 shop t shop_variant_type_handler             layout
+base t cms_image_crop_preset                 layout
 base t cms_config_themes                     layout
 base t cms_font_image                        layout
 base t cms_url_alias                         routing

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1551797432.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1551797432.inc.php
@@ -5,8 +5,28 @@
 </div>
 <?php
 
+use Doctrine\Common\Collections\Expr\Comparison;
+
+/*
+ * Remove some items from the main menu as they are outdated
+ */
+$data = TCMSLogChange::createMigrationQueryData('cms_tbl_conf', 'en')
+    ->setFields([
+        'cms_content_box_id' => '',
+    ])
+    ->setWhereExpressions([
+        new Comparison('name', Comparison::IN, [
+            'cms_dark_site_content',
+            'shop_suggest_article_log',
+            'shop_variant_type',
+        ]),
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
 /**
  * @var ChameleonSystem\CoreBundle\Bridge\Chameleon\Migration\Service\MainMenuMigrator $mainMenuMigrator
  */
 $mainMenuMigrator = \ChameleonSystem\CoreBundle\ServiceLocator::get('chameleon_system_core.service.main_menu_migrator');
+$mainMenuMigrator->migrateUnhandledContentBoxes();
 $mainMenuMigrator->migrateUnhandledTableMenuItems();

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -880,7 +880,6 @@
 
         <service id="chameleon_system_core.service.main_menu_migrator" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Migration\Service\MainMenuMigrator">
             <argument id="database_connection" type="service"/>
-            <argument id="chameleon_system_core.tools" type="service"/>
             <argument id="chameleon_system_core.util.field_translation" type="service"/>
         </service>
     </services>

--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -1449,6 +1449,8 @@ class TCMSLogChange
      * @param string $sSystemName of the content box
      *
      * @return string content box id OR empty string
+     *
+     * @deprecated since 6.3.0 - only used for deprecated classic main menu
      */
     public static function getCmsContentBoxIdFromSystemName($sSystemName)
     {


### PR DESCRIPTION
- Some menu items are not required and are now excluded from menu item generation
- Menu category and menu item generation are now more clearly separated
- Improved some naming
- Cleanup

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#361
| License       | MIT
