### PR TITLE
ref #65: Disallow JavasScript in WYSIWYG fields by default

### DIFF
--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -9,6 +9,14 @@ Support for Adobe Flash was removed. We recommend to search the media manager fo
 extensions "flv", "f4v" and "swf") and remove them.
 The media manager will also display where these files are still used; these usages should also be removed.
 
+# Informational
+
+## JavaScript disallowed in WYSIWYG fields by default
+
+JavaScript in WYSIWYG fields poses a potential security risk which is why it is now disallowed by default. If the
+project requires WYSIWYG JavaScript, allow it by setting the configuration key
+`chameleon_system_cms_text_field: allow_script_tags: true`.
+
 # Changed Features
 
 ## Changed Interfaces and Method Signatures

--- a/src/CmsTextFieldBundle/DependencyInjection/Configuration.php
+++ b/src/CmsTextFieldBundle/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
         $root
             ->children()
                 ->booleanNode('allow_script_tags')
-                    ->defaultTrue()
+                    ->defaultFalse()
                 ->info('If set to false, script tags are removed on display. This is a security feature: 
                 If an attacker somehow manages to gain access to the backend, they cannot inject scripts.
                 Consider setting this option to false if script support in text fields is not required.')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#65
| License       | MIT
