### PR TITLE
ref #377: Set reset option manually as it didn't work in the intended…

### DIFF
--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldDocument/fieldDocument.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldDocument/fieldDocument.html.twig
@@ -1,6 +1,6 @@
 
 {% set selectOptions -%}
-    {"placeholder": "{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}", "allowClear": true, "width": "100%" }
+    { "width": "100%" }
 {%- endset %}
 
 <div class="fieldDocument">
@@ -28,7 +28,7 @@
             <div class="form-group mb-0">
                 <label>{{ 'chameleon_system_core.field_document.upload'|trans }}</label>
                 <select name="documentTreeId_{{ fieldName |e('html_attr') }}" id="documentTreeId_{{ fieldName |e('html_attr') }}" class="{{ sClass |e('html_attr') }}" data-select2-option='{{ selectOptions }}' >
-                    <option></option>
+                    <option value="">{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}</option>
                     {{ optionsHTML|raw }}
                 </select>
             </div>

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookup.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookup.html.twig
@@ -1,5 +1,5 @@
 {% set selectOptions -%}
-    {"placeholder": "{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}"{% if allowEmptySelection %}, "allowClear": true{% endif %}, "width": "100%" }
+    { "width": "100%" }
 {%- endset %}
 
 <div class="fieldLookup row">
@@ -7,7 +7,7 @@
         <select name="{{ fieldName|e('html_attr') }}" id="{{ fieldName|e('html_attr') }}"
                 class="{{ sClass|e('html_attr') }}" data-select2-option='{{ selectOptions }}'>
             {% if allowEmptySelection %}
-                <option></option>
+                <option value="">{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}</option>
             {% endif %}
             {% for key, option in options %}
                 {% if key == connectedRecordId %}

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookupFieldTypes.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookupFieldTypes.html.twig
@@ -1,14 +1,11 @@
 {% set selectOptions -%}
-    {"placeholder": "{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}"{% if allowEmptySelection %}, "allowClear": true{% endif %}, "width": "100%" }
+    { "width": "100%" }
 {%- endset %}
 
 <div class="lookup-container-field-types row">
     <div class="col-12 col-lg-6">
         <select name="{{ fieldName|e('html_attr') }}" id="{{ fieldName|e('html_attr') }}" class="{{ sClass|e('html_attr') }}"
                 data-select2-option='{{ selectOptions|e('html_attr') }}'>
-            {% if allowEmptySelection %}
-                <option></option>
-            {% endif %}
             {% set helpText = "" %}
             {% for key, option in options %}
                 {% if key == connectedRecordId %}


### PR DESCRIPTION
… way

| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#377
| License       | MIT

fieldLookupFieldTypes.html.twig only has a single purpose and there we don't need to set an empty selection, so I removed it from that view.