### PR TITLE
ref #381: backport from 7.0: reset field class and fix translations f…

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1553768043.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1553768043.inc.php
@@ -27,3 +27,5 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
     ])
 ;
 TCMSLogChange::update(__LINE__, $data);
+
+TCMSLogChange::addInfoMessage('The "width" field in "cms_media" was restored to the default numeric field. If you need to work with the old Media Manager you may set the field class back to "TCMSFieldMediaProperties" till upgrading to 7.0 or newer.');

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1553768043.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1553768043.inc.php
@@ -1,0 +1,29 @@
+<h1>Build #1553768043</h1>
+<h2>Date: 2019-03-28</h2>
+<div class="changelog">
+    - Reset field class and fix translations for cms_media.width
+</div>
+<?php
+
+$fieldId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('cms_media'), 'width');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
+    ->setFields([
+        'translation' => 'Width',
+        'fieldclass' => '',
+    ])
+    ->setWhereEquals([
+        'id' => $fieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields([
+        'translation' => 'Breite',
+    ])
+    ->setWhereEquals([
+        'id' => $fieldId,
+    ])
+;
+TCMSLogChange::update(__LINE__, $data);


### PR DESCRIPTION
…or cms_media.width

| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#381
| License       | MIT



