### PR TITLE
ref #393: Avoid going back in history

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -585,10 +585,6 @@ function SaveViaAjaxCallback(data, statusText) {
 
         $('#tableEditorContainer .navbar-brand').html(data.name);
         $('#cmsbreadcrumb .breadcrumb-item:last').html(data.name);
-
-        if (self !== top) {
-            window.history.go(-1);
-        }
     } else {
         toasterMessage(CHAMELEON.CORE.i18n.Translate('chameleon_system_core.js.error_save'), 'ERROR');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#393
| License       | MIT

I'm not sure why we needed this "redirect" in the past, but think that it is no longer required because of backend changes in 6.3.x. Not too familiar with this region of the code, maybe @pixeljunkie can tell if this is a good idea.