### PR TITLE
ref #402: Prohibit page call if the page is not part of a navigation

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1554901333.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1554901333.inc.php
@@ -6,5 +6,5 @@
 
 TCMSLogChange::addInfoMessage('Pages are now only available if they are part of a navigation (see navigation
 options in the portal settings). This restores the behavior of a previous Chameleon release; it was never intended that
-any pages are accessible in the frontend. Check if all pages that should be available in the frontend are part of a
+every page is accessible in the frontend. Ensure that all pages that should be available in the frontend are part of a
 navigation.', TCMSLogChange::INFO_MESSAGE_LEVEL_TODO);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1554901333.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1554901333.inc.php
@@ -1,0 +1,10 @@
+<h1>Build #1551195244</h1>
+<h2>Date: 2019-02-26</h2>
+<div class="changelog">
+</div>
+<?php
+
+TCMSLogChange::addInfoMessage('Pages are now only available if they are part of a navigation (see navigation
+options in the portal settings). This restores the behavior of a previous Chameleon release; it was never intended that
+any pages are accessible in the frontend. Check if all pages that should be available in the frontend are part of a
+navigation.', TCMSLogChange::INFO_MESSAGE_LEVEL_TODO);

--- a/src/CoreBundle/Resources/doc/routing.rst
+++ b/src/CoreBundle/Resources/doc/routing.rst
@@ -69,6 +69,12 @@ Portals and Domains
   only match if the request is "caught" by a domain assigned to a portal containing the required page.
 - the portal URL prefix is considered if set (TAdbCmsPortal::$fieldIdentifier).
 
+Navigation
+..........
+
+- A page can only be accessed if it is part of a navigation (i.e. if the primary tree node of the page has a parent
+  node that is registered in the cms_portal_navigation table for the page's portal).
+
 Internationalization
 ....................
 

--- a/src/CoreBundle/private/library/classes/routing/TPkgCmsRouteControllerCmsTplPage.class.php
+++ b/src/CoreBundle/private/library/classes/routing/TPkgCmsRouteControllerCmsTplPage.class.php
@@ -119,11 +119,11 @@ class TPkgCmsRouteControllerCmsTplPage extends AbstractRouteController
         $lowerCasedPagePath = mb_strtolower($normalizedPagePath);
 
         $routes = $this->routingUtil->getAllPageRoutes($activePortal, $activeLanguage);
-        foreach ($routes as $pagedef => $routesToPage) {
+        foreach ($routes as $pageId => $routesToPage) {
             foreach ($routesToPage->getPathList() as $comparePath) {
                 $lowerCasedComparePath = mb_strtolower($comparePath);
                 if ($lowerCasedComparePath === $lowerCasedPagePath) {
-                    return $pagedef;
+                    return $pageId;
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | see below
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#402-->
| License       | MIT

We should be careful when merging this fix. While it fixes a BC break, this break has been around for some time, so people might rely on the current behavior. I included an update message to warn developers though.