### PR TITLE
ref #436: Do not allow html in regular alert messages

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/cms.js
+++ b/src/CoreBundle/Resources/public/javascript/cms.js
@@ -87,7 +87,7 @@ function AjaxError(XMLHttpRequest, textStatus, errorThrown) {
                     top.document.location.href = window.location.pathname;
                 }
             } else {
-                alert(errorMessage);
+                toasterMessage(errorMessage, "ERROR");
             }
         }
     } else {

--- a/src/CoreBundle/Resources/public/javascript/cms.js
+++ b/src/CoreBundle/Resources/public/javascript/cms.js
@@ -134,7 +134,8 @@ function toasterMessage(message,type) {
 window.alert = function(message) {
     new PNotify({
         title: "Alert",
-        text: message
+        text: message,
+        text_escape: true
     });
 };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe - everything (external) that currently relies on alert() showing html
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#436
| License       | MIT
