### PR TITLE
ref #427: Make getDefaultPortal() more reliable

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1561369084.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1561369084.inc.php
@@ -1,0 +1,23 @@
+<h1>Build #1561369084</h1>
+<h2>Date: 2019-06-24</h2>
+<div class="changelog">
+    - #427: Check for interfering first portal
+</div>
+<?php
+
+$connection = TCMSLogChange::getDatabaseConnection();
+
+$firstPortalId = $connection->fetchColumn('SELECT `id` FROM `cms_portal` ORDER BY `id` ASC LIMIT 1');
+
+$primaryPortalId = $connection->fetchColumn('SELECT `cms_portal_id` FROM `cms_config`');
+
+if ($firstPortalId !== $primaryPortalId) {
+    TCMSLogChange::addInfoMessage(
+        sprintf(
+            'Your default portal changed (result of PortalDomainService::getDefaultPortal()): It was the one with id %s and is now the one configured as primary %s.',
+            $firstPortalId,
+            $primaryPortalId
+        ),
+        TCMSLogChange::INFO_MESSAGE_LEVEL_WARNING
+    );
+}

--- a/src/CoreBundle/Service/PortalDomainService.php
+++ b/src/CoreBundle/Service/PortalDomainService.php
@@ -40,10 +40,6 @@ class PortalDomainService implements PortalDomainServiceInterface
      */
     private $domain;
     /**
-     * @var TdbCmsPortal
-     */
-    private $defaultPortal;
-    /**
      * @var array|null
      */
     private $portalDomainNames;
@@ -121,18 +117,7 @@ class PortalDomainService implements PortalDomainServiceInterface
      */
     public function getDefaultPortal()
     {
-        if (null !== $this->defaultPortal) {
-            return $this->defaultPortal;
-        }
-
-        $portalList = TdbCmsPortalList::GetList();
-        $portalList->GoToStart();
-        $this->defaultPortal = $portalList->Current();
-        if (false === $this->defaultPortal) {
-            return null;
-        }
-
-        return $this->defaultPortal;
+        return \TdbCmsConfig::GetInstance()->GetPrimaryPortal();
     }
 
     /**

--- a/src/CoreBundle/Service/PortalDomainServiceInterface.php
+++ b/src/CoreBundle/Service/PortalDomainServiceInterface.php
@@ -35,7 +35,7 @@ interface PortalDomainServiceInterface
     public function getActivePortal();
 
     /**
-     * Returns the first defined portal.
+     * Returns the primary portal (cms config).
      *
      * @return null|TdbCmsPortal
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no - slightly: method changes from "first portal" to "primary portal"
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#427
| License       | MIT
