### PR TITLE
ref #429: Use source type to avoid using Twig for strings (Twig only …

### DIFF
--- a/src/SnippetRendererBundle/objects/PkgAbstractSnippetRenderer.class.php
+++ b/src/SnippetRendererBundle/objects/PkgAbstractSnippetRenderer.class.php
@@ -21,9 +21,12 @@ abstract class PkgAbstractSnippetRenderer implements IPkgSnippetRenderer
     private $sSource = null;
     private $sFile = null;
     private $oSourceModule = null;
+    private $sourceType = IPkgSnippetRenderer::SOURCE_TYPE_STRING;
 
     public function InitializeSource($sSource, $iSourceType = IPkgSnippetRenderer::SOURCE_TYPE_STRING)
     {
+        $this->sourceType = $iSourceType;
+
         switch ($iSourceType) {
             case IPkgSnippetRenderer::SOURCE_TYPE_STRING:
                 $this->setSource($sSource);
@@ -38,6 +41,11 @@ abstract class PkgAbstractSnippetRenderer implements IPkgSnippetRenderer
                 throw new ErrorException('invalid source type ', 0, E_USER_ERROR);
                 break;
         }
+    }
+
+    protected function getSourceType(): int
+    {
+        return $this->sourceType;
     }
 
     /**

--- a/src/SnippetRendererBundle/objects/TPkgSnippetRenderer.class.php
+++ b/src/SnippetRendererBundle/objects/TPkgSnippetRenderer.class.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+use ChameleonSystem\CoreBundle\ServiceLocator;
+
 /**
  * TPkgSnippetRenderer - a simple yet effective renderer for HTML snippets.
  *
@@ -90,7 +92,7 @@ class TPkgSnippetRenderer extends PkgAbstractSnippetRenderer
      */
     public static function GetNewInstance($sSource, $iSourceType = IPkgSnippetRenderer::SOURCE_TYPE_STRING)
     {
-        $oNewInstance = \ChameleonSystem\CoreBundle\ServiceLocator::get(
+        $oNewInstance = ServiceLocator::get(
             'chameleon_system_snippet_renderer.snippet_renderer'
         );
         $oNewInstance->InitializeSource($sSource, $iSourceType);
@@ -144,10 +146,18 @@ class TPkgSnippetRenderer extends PkgAbstractSnippetRenderer
             $this->setFilename($this->getSourceModule()->viewTemplate);
         }
 
-        try {
-            $content = $this->getTwigHandler()->render($this->getSource(), $this->getVars());
-        } catch (Twig_Error $e) {
-            throw new TPkgSnippetRenderer_SnippetRenderingException(sprintf("%s\nin file %s at line %s\n", $e->getMessage(), $e->getFile(), $e->getLine()), $e->getCode(), $e);
+        if ($this->getSourceType() !== IPkgSnippetRenderer::SOURCE_TYPE_STRING) {
+            try {
+                $content = $this->getTwigHandler()->render($this->getSource(), $this->getVars());
+            } catch (Twig_Error $e) {
+                throw new TPkgSnippetRenderer_SnippetRenderingException(
+                    sprintf("%s\nin file %s at line %s\n", $e->getMessage(), $e->getFile(), $e->getLine()),
+                    $e->getCode(),
+                    $e
+                );
+            }
+        } else {
+            $content = $this->getSource();
         }
 
         return $content;


### PR DESCRIPTION
…supports files)

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no - unlikely: not _everything_ is processed with Twig anymore
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#429
| License       | MIT
