### PR TITLE
ref #434: Use a value != 0 as default for height (as TCMSImage::GetTh…

### DIFF
--- a/src/SnippetRendererBundle/Filter/TPkgSnippetRendererFilter.class.php
+++ b/src/SnippetRendererBundle/Filter/TPkgSnippetRendererFilter.class.php
@@ -27,7 +27,7 @@ class TPkgSnippetRendererFilter
     public static function getThumbnail(
         $cmsMediaId,
         $maxWidth,
-        $maxHeight = 0,
+        $maxHeight = 2000,
         $forceSize = false,
         $returnAbsoluteUrl = null
     ) {


### PR DESCRIPTION
…umbnail does)

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no - slightly: method value default changed - but any "using code" does currently not rely on this value (hopefully) as it produces undesired results
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#434
| License       | MIT
