### PR TITLE
ref #465: Remove doubled html escape from file name output

### DIFF
--- a/src/CoreBundle/Resources/views/snippets-cms/common/download/download.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/common/download/download.html.twig
@@ -6,9 +6,9 @@
     {%- endset %}
 {% endif %}
 
- {% set fileName = downloadLink.fileName|e('html') %}
-{% if not downloadLink.showFilename %}
-    {% set fileName = '&nbsp;' %}
+{% set fileName = '&nbsp;' %}
+{% if downloadLink.showFilename %}
+    {% set fileName = downloadLink.fileName %}
 {% endif %}
 
 <span class="cmsdownloaditem" {{ downloadId|raw }}>

--- a/src/CoreBundle/Resources/views/snippets/common/download/download.html.twig
+++ b/src/CoreBundle/Resources/views/snippets/common/download/download.html.twig
@@ -6,9 +6,9 @@
     {%- endset %}
 {% endif %}
 
- {% set fileName = downloadLink.fileName|e('html') %}
-{% if not downloadLink.showFilename %}
-    {% set fileName = '&nbsp;' %}
+{% set fileName = '&nbsp;' %}
+{% if downloadLink.showFilename %}
+    {% set fileName = downloadLink.fileName %}
 {% endif %}
 
 <span class="cmsdownloaditem" {{ downloadId|raw }}>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#465
| License       | MIT

Correct target branch.