### PR TITLE
ref #400: vertical scrollbar toggles when iframe's body set to min-he…

### DIFF
--- a/src/CoreBundle/Resources/public/themes/standard/css/global.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/global.css
@@ -253,6 +253,11 @@ legend {
     color: #000000 !important;
 }
 
+/* overwrite min-height: 100vh; set from coreui */
+body.app {
+    min-height: 100%;
+}
+
 /**
 Bootstrap 4 addons.
  */


### PR DESCRIPTION
…ight: 100vh

| Q             | A
| ------------- | ---
| Branch        | features / 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#400
| License       | MIT

Inside an iframe "body.app" is set by coreui to a min-height of 100vh. This leads to problems with the Symfony bar (fixed bottom), which then toggles the vertical scrollbar.
If the min-height is set to 100% instead of 100vh, it works fine.

