### PR TITLE
Fix/539 improve no portal handling

### DIFF
--- a/src/CoreBundle/Controller/ExceptionController.php
+++ b/src/CoreBundle/Controller/ExceptionController.php
@@ -152,6 +152,9 @@ class ExceptionController extends \Symfony\Bundle\TwigBundle\Controller\Exceptio
             return;
         }
         $portal = $this->portalDomainService->getActivePortal();
+        if (null === $portal) {
+            return null;
+        }
         $nodeId = null;
         if (404 === $code) {
             $nodeId = $portal->fieldPageNotFoundNode;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#539
| License       | MIT

When no matching domain is found for a request (because no domain exists, or the domain is disabled) a notice about accessing a property of a none object will be thrown.

This makes it more difficult to finde the actual error - and can be easily corrected.
