### PR TITLE
Fix/539 php 74 support in template edit mode 6.3

### DIFF
--- a/src/CoreBundle/TemplateEngine/Mapper/ModuleChooserModuleListMapper.php
+++ b/src/CoreBundle/TemplateEngine/Mapper/ModuleChooserModuleListMapper.php
@@ -58,7 +58,7 @@ class ModuleChooserModuleListMapper extends AbstractViewMapper
                 'icon' => $moduleObject->fieldIconFontCssClass,
                 'views' => array(),
             );
-            $moduleObject->aPermittedViews = $permittedModules[$moduleObject->fieldClassname];
+            $moduleObject->aPermittedViews = $permittedModules[$moduleObject->fieldClassname] ?? null;
             /** @var $views \TIterator */
             $views = $moduleObject->GetViews();
             if (0 === $views->Length()) {

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldLookup.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldLookup.class.php
@@ -385,7 +385,7 @@ class TCMSFieldLookup extends TCMSField
 
             $query = "SELECT * FROM cms_tbl_conf where `name` = '".MySqlLegacySupport::getInstance()->real_escape_string($this->GetConnectedTableName())."'";
             $aTargetTable = MySqlLegacySupport::getInstance()->fetch_assoc(MySqlLegacySupport::getInstance()->query($query));
-            $aMethodData['sClassType'] = $aTargetTable['dbobject_type'];
+            $aMethodData['sClassType'] = $aTargetTable['dbobject_type'] ?? '';
 
             $oViewParser = new TViewParser();
             $oViewParser->bShowTemplatePathAsHTMLHint = false;
@@ -414,7 +414,7 @@ class TCMSFieldLookup extends TCMSField
         $sInputName = 'i'.ucfirst(TCMSTableToClass::ConvertToClassString($this->name));
         $aParameters = array(
             $sInputName => array(
-                'description' => 'ID for the record in: '.$aTableConf['translation'],
+                'description' => 'ID for the record in: '.($aTableConf['translation'] ?? ' [not found]'),
                 'default' => '',
                 'sType' => 'int',
             ),
@@ -435,12 +435,12 @@ class TCMSFieldLookup extends TCMSField
         $aMethodData['sClassSubType'] = 'CMSDataObjects';
         $aMethodData['sVisibility'] = 'static public';
 
-        $aMethodData['sClassType'] = $aTableConf['dbobject_type'];
+        $aMethodData['sClassType'] = $aTableConf['dbobject_type'] ?? '';
 
         $aMethodData['iLookupFieldName'] = $sInputName;
         $aMethodData['sTableDatabaseName'] = $this->sTableName;
 
-        $aMethodData['aFieldData']['sFieldFullName'] = 'Return all records belonging to the '.$aTableConf['translation'];
+        $aMethodData['aFieldData']['sFieldFullName'] = 'Return all records belonging to the '.($aTableConf['translation'] ?? ' [not found]');
 
         $oViewParser = new TViewParser();
         $oViewParser->bShowTemplatePathAsHTMLHint = false;

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldModuleInstance.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldModuleInstance.class.php
@@ -378,7 +378,7 @@ class TCMSFieldModuleInstance extends TCMSFieldExtendedLookup
             $query = "SELECT * FROM cms_tbl_conf where `name` = '".MySqlLegacySupport::getInstance()->real_escape_string($this->GetConnectedTableName())."'";
             $aTargetTable = MySqlLegacySupport::getInstance()->fetch_assoc(MySqlLegacySupport::getInstance()->query($query));
 
-            $aMethodData['sClassType'] = $aTargetTable['dbobject_type'];
+            $aMethodData['sClassType'] = $aTargetTable['dbobject_type'] ?? '';
 
             $oViewParser = new TViewParser();
             $oViewParser->bShowTemplatePathAsHTMLHint = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#539
| License       | MIT

The system attempts to access an array entry in the permitted modules list - even when that list is empty. That will result in a notice which in turn will throw an exception in dev mode