### PR TITLE
ref #107: missing services global and request_stack in NavigationTree…

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
@@ -17,6 +17,7 @@ use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use TGlobal;
 
 /**
  * {@inheritdoc}
@@ -33,9 +34,10 @@ class NavigationTreeSingleSelectWysiwyg extends NavigationTreeSingleSelect
         EventDispatcherInterface $eventDispatcher,
         InputFilterUtilInterface $inputFilterUtil,
         BackendTreeNodeFactory $backendTreeNodeFactory,
+        TGlobal $global,
         RequestStack $requestStack
     ) {
-        parent::__construct($dbConnection, $eventDispatcher, $inputFilterUtil, $backendTreeNodeFactory);
+        parent::__construct($dbConnection, $eventDispatcher, $inputFilterUtil, $backendTreeNodeFactory, $global);
         $this->requestStack = $requestStack;
     }
 

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -944,6 +944,8 @@
             <argument id="event_dispatcher" type="service"/>
             <argument id="chameleon_system_core.util.input_filter" type="service"/>
             <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
+            <argument id="chameleon_system_core.global" type="service"/>
+            <argument id="request_stack" type="service"/>
             <argument id="chameleon_system_core.cache" type="service"/>
         </service>
 


### PR DESCRIPTION
…SingleSelectWysiwyg.php

| Q             | A
| ------------- | ---
| Branch        | features / 6.3.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#107
| License       | MIT

In NavigationTreeSingleSelectWysiwyg the services global and request_stack were missing. This led to an error.