### PR TITLE
Feature/572 navigation tree with several status icons

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1590161610.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1590161610.inc.php
@@ -1,0 +1,28 @@
+<h1>Build #1590161610</h1>
+<h2>Date: 2020-05-22</h2>
+<div class="changelog">
+    - #572: portals: add fielClass 'TCMSFieldPortalHomeTreeNode' to field 'page_not_found_node'
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+  ->setFields([
+      'fieldclass' => 'TCMSFieldPortalHomeTreeNode',
+  ])
+  ->setWhereEquals([
+      'name' => 'page_not_found_node',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+
+$query ="ALTER TABLE `cms_portal` DROP INDEX `page_not_found_node`";
+TCMSLogChange::RunQuery(__LINE__, $query);
+
+$query ="ALTER TABLE `cms_portal`
+                     CHANGE `page_not_found_node`
+                            `page_not_found_node` CHAR(36) NOT NULL COMMENT '404-Page-Not-Found-Seite: '";
+TCMSLogChange::RunQuery(__LINE__, $query);
+
+$query ="ALTER TABLE `cms_portal` ADD INDEX `page_not_found_node` (`page_not_found_node`)";
+TCMSLogChange::RunQuery(__LINE__, $query);
+

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
@@ -352,7 +352,7 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
     private function createBreadcrumbStorage(\TdbCmsTree $node, $path = ''): string
     {
         $path .= '<li class="breadcrumb-item">'.$node->fieldName.'</li>';
-        $breadcrumbStorageHTML = '<div id="'.$this->fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb ml-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
+        $breadcrumbStorageHTML = '<div id="'.$this->fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb pl-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
 
         $children = $node->GetChildren(true);
         while ($child = $children->Next()) {

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
@@ -695,10 +695,6 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
         $this->addIconToTreeNode($treeNodeDataModel, 'page', 'far fa-file');
         $treeNodeDataModel->addListAttribute('isPageId', $linkedPageOfNode->id);
 
-        if ('' !== $this->currentPageId) {
-            $treeNodeDataModel->setDisabled(true);
-        }
-
         if (true === $linkedPageOfNode->fieldExtranetPage) {
             $treeNodeDataModel->addLinkHtmlClass('locked');
             $this->addIconToTreeNode($treeNodeDataModel, 'locked', 'fas fa-user-lock');
@@ -710,19 +706,23 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
 
         // current page is connected to this node
         if ($this->currentPageId === $linkedPageOfNode->id) {
-            $treeNodeDataModel->addLinkHtmlClass('activeConnectedNode');
+            $treeNodeDataModel->addListHtmlClass('activeConnectedNode');
             $treeNodeDataModel->setOpened(true);
             $treeNodeDataModel->setSelected(true);
-            if ('' !== $this->currentPageId) {
-                $treeNodeDataModel->setDisabled(false);
-            }
 
             if ($this->primaryConnectedNodeIdOfCurrentPage === $node->id) {
-                $treeNodeDataModel->addLinkHtmlClass('primaryConnectedNode');
-                $treeNodeDataModel->setDisabled(true);
+                $treeNodeDataModel->addListHtmlClass('primaryConnectedNodeOfCurrentPage');
+                if ('' !== $this->currentPageId) {
+                    $treeNodeDataModel->setDisabled(true);
+                    $treeNodeDataModel->addListHtmlClass('no-checkbox');
+                }
             }
         } else {
             $treeNodeDataModel->addLinkHtmlClass('otherConnectedNode');
+            if ('' !== $this->currentPageId) {
+                $treeNodeDataModel->setDisabled(true);
+                $treeNodeDataModel->addListHtmlClass('no-checkbox');
+            }
         }
     }
 

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
@@ -764,7 +764,7 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
         if ('' === $treeNodeDataModel->getType()) {
             $treeNodeDataModel->setType($type);
         } else {
-            $treeNodeDataModel->addFurtherIcon('<i class="'. $fontawesomeIcon .' mr-2"></i>');
+            $treeNodeDataModel->addFurtherIconHTML('<i class="'. $fontawesomeIcon .' mr-2"></i>');
         }
     }
 

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
@@ -188,7 +188,7 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
             $rootNode = new \TdbCmsTree();
             $rootNode->SetLanguage(\TdbCmsUser::GetActiveUser()->GetCurrentEditLanguageID());
             $rootNode->Load($this->rootNodeId);
-            $visitor->SetMappedValue('breadcrumbStorageHTML', $this->createBreadcrumbStorage($rootNode));
+            $visitor->SetMappedValue('pageBreadcrumbsHTML', $this->createPageBreadcrumbs($rootNode));
         }
 
 
@@ -349,17 +349,17 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
         }
     }
 
-    private function createBreadcrumbStorage(\TdbCmsTree $node, $path = ''): string
+    private function createPageBreadcrumbs(\TdbCmsTree $node, $path = ''): string
     {
         $path .= '<li class="breadcrumb-item">'.$node->fieldName.'</li>';
-        $breadcrumbStorageHTML = '<div id="'.$this->fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb pl-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
+        $pageBreadcrumbsHTML = '<div id="'.$this->fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb pl-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
 
         $children = $node->GetChildren(true);
         while ($child = $children->Next()) {
-            $breadcrumbStorageHTML .= $this->createBreadcrumbStorage($child, $path);
+            $pageBreadcrumbsHTML .= $this->createPageBreadcrumbs($child, $path);
         }
 
-        return $breadcrumbStorageHTML;
+        return $pageBreadcrumbsHTML;
     }
 
     /**

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTree/NavigationTree.php
@@ -694,7 +694,10 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
 
         $this->addIconToTreeNode($treeNodeDataModel, 'page', 'far fa-file');
         $treeNodeDataModel->addListAttribute('isPageId', $linkedPageOfNode->id);
-        $treeNodeDataModel->setDisabled(true);
+
+        if ('' !== $this->currentPageId) {
+            $treeNodeDataModel->setDisabled(true);
+        }
 
         if (true === $linkedPageOfNode->fieldExtranetPage) {
             $treeNodeDataModel->addLinkHtmlClass('locked');
@@ -710,7 +713,9 @@ class NavigationTree extends MTPkgViewRendererAbstractModuleMapper
             $treeNodeDataModel->addLinkHtmlClass('activeConnectedNode');
             $treeNodeDataModel->setOpened(true);
             $treeNodeDataModel->setSelected(true);
-            $treeNodeDataModel->setDisabled(false);
+            if ('' !== $this->currentPageId) {
+                $treeNodeDataModel->setDisabled(false);
+            }
 
             if ($this->primaryConnectedNodeIdOfCurrentPage === $node->id) {
                 $treeNodeDataModel->addLinkHtmlClass('primaryConnectedNode');

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
@@ -154,7 +154,7 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
             $rootNode = new \TdbCmsTree();
             $rootNode->SetLanguage(\TdbCmsUser::GetActiveUser()->GetCurrentEditLanguageID());
             $rootNode->Load($rootTreeId);
-            $visitor->SetMappedValue('breadcrumbStorageHTML', $this->createBreadcrumbStorage($rootNode, $fieldName));
+            $visitor->SetMappedValue('breadcrumbStorageHTML', $this->createPageBreadcrumbs($rootNode, $fieldName));
         }
 
         $visitor->SetMappedValue('fieldName', $fieldName);
@@ -396,17 +396,17 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
     {
     }
 
-    private function createBreadcrumbStorage(\TdbCmsTree $node, $fieldName, $path = ''): string
+    private function createPageBreadcrumbs(\TdbCmsTree $node, $fieldName, $path = ''): string
     {
         $path .= '<li class="breadcrumb-item">'.$fieldName.'</li>';
-        $breadcrumbStorageHTML = '<div id="'.$fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb pl-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
+        $pageBreadcrumbsHTML = '<div id="'.$fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb pl-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
 
         $children = $node->GetChildren(true);
         while ($child = $children->Next()) {
-            $breadcrumbStorageHTML .= $this->createBreadcrumbStorage($child, $fieldName, $path);
+            $pageBreadcrumbsHTML .= $this->createPageBreadcrumbs($child, $fieldName, $path);
         }
 
-        return $breadcrumbStorageHTML;
+        return $pageBreadcrumbsHTML;
     }
 
     /**

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
@@ -13,14 +13,27 @@ namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingl
 
 use ChameleonSystem\CoreBundle\DataModel\BackendTreeNodeDataModel;
 use ChameleonSystem\CoreBundle\Factory\BackendTreeNodeFactory;
+use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
+use ChameleonSystem\CoreBundle\Util\FieldTranslationUtil;
 use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
+use ChameleonSystem\CoreBundle\Util\UrlUtil;
 use Doctrine\DBAL\Connection;
 use MTPkgViewRendererAbstractModuleMapper;
+use phpDocumentor\Reflection\Types\Boolean;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use TGlobal;
+use TTools;
 
 class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
 {
+    /**
+     * The mysql tablename of the tree.
+     *
+     * @var string
+     */
+    private $treeTable = 'cms_tree';
+
     /**
      * @var Connection
      */
@@ -33,14 +46,36 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
      * @var InputFilterUtilInterface
      */
     private $inputFilterUtil;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var UrlUtil
+     */
+    private $urlUtil;
     /**
      * @var BackendTreeNodeFactory
      */
     private $backendTreeNodeFactory;
+
     /**
      * @var string
      */
-    private $treePathHTML = '';
+    private $fieldName;
+
+    /**
+     * @var string
+     */
+    private $activeNodeId;
+
+
+    /**
+     * @var string
+     */
+    private $isPortalSelectMode;
 
     /**
      * Nodes that should not be assignable or that should have only a
@@ -51,22 +86,48 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
     protected $restrictedNodes = [];
 
     /**
+     * @var TTools
+     */
+    private $tools;
+
+    /**
      * @var TGlobal
      */
     private $global;
+
+    /**
+     * @var FieldTranslationUtil
+     */
+    private $fieldTranslationUtil;
+
+    /**
+     * @var \TdbCmsLanguage
+     */
+    private $editLanguage;
 
     public function __construct(
         Connection $dbConnection,
         EventDispatcherInterface $eventDispatcher,
         InputFilterUtilInterface $inputFilterUtil,
+        UrlUtil $urlUtil,
         BackendTreeNodeFactory $backendTreeNodeFactory,
-        TGlobal $global
+        TranslatorInterface $translator,
+        TTools $tools,
+        TGlobal $global,
+        FieldTranslationUtil $fieldTranslationUtil,
+        LanguageServiceInterface $languageService
     ) {
         $this->dbConnection = $dbConnection;
         $this->eventDispatcher = $eventDispatcher;
         $this->inputFilterUtil = $inputFilterUtil;
+        $this->urlUtil = $urlUtil;
         $this->backendTreeNodeFactory = $backendTreeNodeFactory;
+        $this->translator = $translator;
+        $this->tools = $tools;
         $this->global = $global;
+        $this->fieldTranslationUtil = $fieldTranslationUtil;
+
+        $this->editLanguage = $languageService->getActiveEditLanguage();
     }
 
     /**
@@ -74,10 +135,13 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
      */
     public function Accept(\IMapperVisitorRestricted $visitor, $cachingEnabled, \IMapperCacheTriggerRestricted $cacheTriggerManager)
     {
-        $fieldName = $this->inputFilterUtil->getFilteredGetInput('fieldName', '');
-        $activeNodeId = $this->inputFilterUtil->getFilteredGetInput('id', '');
+        $this->fieldName = $this->inputFilterUtil->getFilteredGetInput('fieldName', '');
+        $this->activeNodeId = $this->inputFilterUtil->getFilteredGetInput('id', '');
+        $currentPageId = $this->inputFilterUtil->getFilteredGetInput('currentPageId', '');
         $portalSelect = $this->inputFilterUtil->getFilteredGetInput('portalSelect', 0);
-        $isPortalSelectMode = $portalSelect === '1' ? true : false;
+        $this->isPortalSelectMode = $portalSelect === '1' ? true : false;
+        $pagesTableName = 'cms_tpl_page';
+
 
         $this->restrictedNodes = $this->getPortalNavigationStartNodes();
 
@@ -86,15 +150,105 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
             $rootNode = new \TdbCmsTree();
             $rootNode->SetLanguage(\TdbCmsUser::GetActiveUser()->GetCurrentEditLanguageID());
             $rootNode->Load($rootTreeId);
-
-            $treeNodes = $this->createTreeDataModel($rootNode, $fieldName);
-            $visitor->SetMappedValue('treeNodes', $treeNodes);
+            $visitor->SetMappedValue('breadcrumbStorageHTML', $this->createBreadcrumbStorage($rootNode));
         }
-        $visitor->SetMappedValue('treePathHTML', $this->treePathHTML);
-        $visitor->SetMappedValue('activeId', $activeNodeId);
-        $visitor->SetMappedValue('fieldName', $fieldName);
+
+        // activeNodeId = aktuell gewählter Node, nötig um die checkbox zu selektieren
+        $visitor->SetMappedValue('activeId', $this->activeNodeId);
+        $visitor->SetMappedValue('fieldName', $this->fieldName);
         $visitor->SetMappedValue('level', 0);
-        $visitor->SetMappedValue('isPortalSelectMode', $isPortalSelectMode);
+        $visitor->SetMappedValue('isPortalSelectMode', $this->isPortalSelectMode);
+
+
+        $url = $this->urlUtil->getArrayAsUrl(
+            [
+                'pagedef' => 'navigationTreeSingleSelect',
+                'module_fnc' =>
+                    [
+                        'contentmodule' => 'ExecuteAjaxCall'
+                    ],
+                '_fnc' => 'getTreeNodes',
+                'activeNodeId' => $this->activeNodeId,
+                'rootTreeId' => $rootTreeId,
+                'fieldName' => $this->fieldName,
+                'isPortalSelectMode' => $this->isPortalSelectMode,
+            ],
+            PATH_CMS_CONTROLLER.'?',
+            '&'
+        );
+        $visitor->SetMappedValue('treeNodesAjaxUrl', $url);
+
+        $url = $this->urlUtil->getArrayAsUrl(
+            [
+                'pagedef' => 'navigationTreeSingleSelect',
+                'module_fnc' =>
+                    [
+                        'contentmodule' => 'ExecuteAjaxCall'
+                    ],
+                '_fnc' => 'updatePrimaryNode',
+                'table' => $pagesTableName,
+                'currentPageId' => $currentPageId,
+                'fieldName' => $this->fieldName
+            ],
+            PATH_CMS_CONTROLLER.'?',
+            '&'
+        );
+        $visitor->SetMappedValue('updatePrimaryNodeUrl', $url);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function DefineInterface()
+    {
+        parent::DefineInterface();
+        $externalFunctions =
+            [
+                'getTreeNodes',
+                'updatePrimaryNode'
+            ];
+        $this->methodCallAllowed = array_merge($this->methodCallAllowed, $externalFunctions);
+    }
+
+    /**
+     * Is called via ajax.
+     * Returns requested treeNode or rootTreeNode (id = "#") with all its children.
+     * The return value is converted to JSON with array brackets around it, jstree.js needs it that way
+     */
+    protected function getTreeNodes(): array
+    {
+        $this->fieldName = $this->inputFilterUtil->getFilteredGetInput('fieldName', '');
+        $this->isPortalSelectMode = $this->inputFilterUtil->getFilteredGetInput('isPortalSelectMode', '');
+        $this->activeNodeId = $this->inputFilterUtil->getFilteredGetInput('activeNodeId', '');
+        $rootTreeId = $this->inputFilterUtil->getFilteredGetInput('rootTreeId', '');
+        if ('' === $rootTreeId) {
+            return [];
+        }
+        $rootNode = new \TdbCmsTree();
+        $rootNode->SetLanguage(\TdbCmsUser::GetActiveUser()->GetCurrentEditLanguageID());
+        $rootNode->Load($rootTreeId);
+
+        $treeData[] = $this->createTreeDataModel($rootNode, 0);
+        return $treeData;
+    }
+
+    /**
+     * Is called via ajax.
+     */
+    protected function updatePrimaryNode(): ?string
+    {
+        $pagesTableName = $this->inputFilterUtil->getFilteredGetInput('table', '');
+        $nodeId = $this->inputFilterUtil->getFilteredGetInput('nodeId', '');
+        $currentPageId = $this->inputFilterUtil->getFilteredGetInput('currentPageId', '');
+        $fieldName = $this->inputFilterUtil->getFilteredGetInput('fieldName', '');
+
+        if ('' === $pagesTableName || '' === $currentPageId || '' === $fieldName) {
+            return null;
+        }
+
+        $tableEditor = $this->tools->GetTableEditorManager($pagesTableName, $currentPageId);
+        $tableEditor->SaveField($fieldName, $nodeId);
+        return $nodeId;
     }
 
     private function getPortalTreeRootNodeId(): string
@@ -113,27 +267,117 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
         return $portal->fieldMainNodeTree;
     }
 
-    private function createTreeDataModel(\TdbCmsTree $node, string $fieldName, $path = ''): BackendTreeNodeDataModel
+    private function createTreeDataModel(\TdbCmsTree $node, int $level, string $path = ''): BackendTreeNodeDataModel
     {
         $treeNodeDataModel = $this->backendTreeNodeFactory->createTreeNodeDataModelFromTreeRecord($node);
+        $treeNodeDataModel->setName($this->translateNodeName($treeNodeDataModel->getName(), $node));
+        $this->setTypeAndAttributes($treeNodeDataModel, $node);
+
+        // $level 0 = portal, 1 = Navigation-Nodes, >1 = folder or page
+        if ($level === 0) {
+            $treeNodeDataModel->setOpened(true);
+        }
+        if ($level <= 1) {
+            $treeNodeDataModel->addListHtmlClass('no-checkbox');
+        }
+
+        ++$level;
         $children = $node->GetChildren(true);
-
-        $path = $this->addBreadcrumbHtmlForNode($node, $fieldName, $path);
-
         while ($child = $children->Next()) {
-            $childTreeNodeObj = $this->createTreeDataModel($child, $fieldName, $path);
+            $childTreeNodeObj = $this->createTreeDataModel($child, $level, $path);
             $treeNodeDataModel->addChildren($childTreeNodeObj);
         }
 
         return $treeNodeDataModel;
     }
 
-    protected function addBreadcrumbHtmlForNode(\TdbCmsTree $node, string $fieldName, string $path = ''): string
-    {
-        $path .= '<li class="breadcrumb-item">'.$node->fieldName."</li>\n";
-        $this->treePathHTML .= '<div id="'.$fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb ml-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
 
-        return $path;
+    private function translateNodeName(string $name, \TdbCmsTree $node): string
+    {
+        $node->SetLanguage($this->editLanguage->id);
+
+        if ('' === $name) {
+            $name = $this->global->OutHTML($this->translator->trans('chameleon_system_core.text.unnamed_record'));
+        }
+
+        if (false === CMS_TRANSLATION_FIELD_BASED_EMPTY_TRANSLATION_FALLBACK_TO_BASE_LANGUAGE) {
+            return $name;
+        }
+
+        if ($this->fieldTranslationUtil->isTranslationNeeded($this->editLanguage)) {
+            $nodeNameFieldName = $this->fieldTranslationUtil->getTranslatedFieldName($this->treeTable, 'name', $this->editLanguage);
+
+            if ('' === $node->sqlData[$nodeNameFieldName]) {
+                $name .= ' <span class="bg-danger px-1"><i class="fas fa-language" title="' . $this->translator->trans('chameleon_system_core.cms_module_table_editor.not_translated') . '"></i></span>';
+            }
+        }
+
+        return $name;
+    }
+
+    private function setTypeAndAttributes(BackendTreeNodeDataModel $treeNodeDataModel, \TdbCmsTree $node): void
+    {
+        $treeNodeDataModel->setType('');
+
+        $children = $node->GetChildren(true);
+        if ($children->Length() > 0) {
+            $treeNodeDataModel->setType('folder');
+        }
+        if (true === $node->fieldHidden) {
+            $this->addIconToTreeNode($treeNodeDataModel, 'nodeHidden', 'fas fa-eye-slash');
+            $treeNodeDataModel->addLinkHtmlClass('node-hidden');
+        }
+        if ('' !== $node->sqlData['link']) {
+            $this->addIconToTreeNode($treeNodeDataModel, 'externalLink', 'fas fa-external-link-alt');
+        }
+
+        $linkedPageOfNode = $node->GetLinkedPageObject(true);
+        if (false === $linkedPageOfNode) {
+            if ('' === $treeNodeDataModel->getType()) {
+                $this->addIconToTreeNode($treeNodeDataModel, 'noPage', 'fas fa-genderless');
+            }
+            return;
+        }
+
+        $this->addIconToTreeNode($treeNodeDataModel, 'page', 'far fa-file');
+
+        if ($this->activeNodeId === $node->id) {
+            $treeNodeDataModel->setSelected(true);
+        } else {
+            $treeNodeDataModel->setDisabled(true);
+            $treeNodeDataModel->addListHtmlClass('no-checkbox');
+        }
+
+        if (true === $linkedPageOfNode->fieldExtranetPage) {
+            $treeNodeDataModel->addLinkHtmlClass('locked');
+            $this->addIconToTreeNode($treeNodeDataModel, 'locked', 'fas fa-user-lock');
+            if (false === $node->fieldShowExtranetPage) {
+                $this->addIconToTreeNode($treeNodeDataModel, 'extranetpageHidden', 'far fa-eye-slash');
+                $treeNodeDataModel->addLinkHtmlClass('extranetpage-hidden');
+            }
+        }
+    }
+
+    private function addIconToTreeNode (BackendTreeNodeDataModel $treeNodeDataModel, string $type, string $fontawesomeIcon): void
+    {
+        if ('' === $treeNodeDataModel->getType()) {
+            $treeNodeDataModel->setType($type);
+        } else {
+            $treeNodeDataModel->addFurtherIcon('<i class="'. $fontawesomeIcon .' mr-2"></i>');
+        }
+    }
+
+    private function createBreadcrumbStorage(\TdbCmsTree $node, $path = ''): string
+    {
+        $path .= '<li class="breadcrumb-item">'.$node->fieldName.'</li>';
+        $breadcrumbStorageHTML = '<div id="'.$this->fieldName.'_tmp_path_'.$node->id.'" style="display:none;"><ol class="breadcrumb ml-0"><li class="breadcrumb-item"><i class="fas fa-sitemap"></i></li>'.$path.'</ol></div>'."\n";
+
+        $children = $node->GetChildren(true);
+        while ($child = $children->Next()) {
+            $breadcrumbStorageHTML .= $this->createBreadcrumbStorage($child, $path);
+        }
+
+        return $breadcrumbStorageHTML;
     }
 
     /**

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
@@ -82,11 +82,6 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
     private $isPortalHomeNodeSelectMode;
 
     /**
-     * @var boolean
-     */
-    private $isPortal404PageSelectMode;
-
-    /**
      * Nodes that should not be assignable or that should have only a
      * restricted context menu.
      *
@@ -230,7 +225,7 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
         $this->fieldName = $this->inputFilterUtil->getFilteredGetInput('fieldName', '');
         $portalSelectMode = $this->inputFilterUtil->getFilteredGetInput('portalSelectMode', '');
         $this->isPortalSelectMode = $portalSelectMode === 'portalSelect' ? true : false;
-        $this->isPortalHomeNodeSelectMode = $portalSelectMode === 'portalHomePage' ? true : false;
+        $this->isPortalHomeNodeSelectMode = $portalSelectMode === 'portalHomePage' ? true : false;  //also 404-page-selection
 
         $this->activeNodeId = $this->inputFilterUtil->getFilteredGetInput('activeNodeId', '');
         $rootTreeId = $this->inputFilterUtil->getFilteredGetInput('rootTreeId', '');
@@ -293,7 +288,7 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
         //"primary-node-selection (from page)" starts with the active portal:
         //   $level: 0 = portal, 1 = Navigation-Nodes, >1 = folder or page
 
-        //"portal-selection" and "portal-404-page-selection" start with root node:
+        //"portal-selection" and "portal-home-page-selection" and "portal-404-page-selection start with root node:
         //   $level: 0 = rootNode (Website), 1 = portal, 2 = Navigation-Nodes, >2 folder or page
         if (true === $this->isPortalSelectMode) {
             if ($level !== 1) {

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
@@ -12,12 +12,18 @@
 namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelectWysiwyg;
 
 use ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelect\NavigationTreeSingleSelect;
+use ChameleonSystem\CoreBundle\DataModel\BackendTreeNodeDataModel;
 use ChameleonSystem\CoreBundle\Factory\BackendTreeNodeFactory;
+use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
+use ChameleonSystem\CoreBundle\Util\FieldTranslationUtil;
 use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
+use ChameleonSystem\CoreBundle\Util\UrlUtil;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\TranslatorInterface;
 use TGlobal;
+use TTools;
 
 /**
  * {@inheritdoc}
@@ -33,11 +39,27 @@ class NavigationTreeSingleSelectWysiwyg extends NavigationTreeSingleSelect
         Connection $dbConnection,
         EventDispatcherInterface $eventDispatcher,
         InputFilterUtilInterface $inputFilterUtil,
+        UrlUtil $urlUtil,
         BackendTreeNodeFactory $backendTreeNodeFactory,
+        TranslatorInterface $translator,
+        TTools $tools,
         TGlobal $global,
+        FieldTranslationUtil $fieldTranslationUtil,
+        LanguageServiceInterface $languageService,
         RequestStack $requestStack
     ) {
-        parent::__construct($dbConnection, $eventDispatcher, $inputFilterUtil, $backendTreeNodeFactory, $global);
+        parent::__construct(
+            $dbConnection,
+            $eventDispatcher,
+            $inputFilterUtil,
+            $urlUtil,
+            $backendTreeNodeFactory,
+            $translator,
+            $tools,
+            $global,
+            $fieldTranslationUtil,
+            $languageService
+        );
         $this->requestStack = $requestStack;
     }
 
@@ -49,5 +71,15 @@ class NavigationTreeSingleSelectWysiwyg extends NavigationTreeSingleSelect
             return;
         }
         $visitor->SetMappedValue('CKEditorFuncNum', $request->query->getInt('CKEditorFuncNum'));
+    }
+
+    protected function disableSelectionWysiwyg(BackendTreeNodeDataModel $treeNodeDataModel): void
+    {
+        $treeNodeDataModel->setDisabled(true);
+        $treeNodeDataModel->addListHtmlClass('no-checkbox');
+    }
+
+    protected function setCheckStatus(BackendTreeNodeDataModel $treeNodeDataModel, $nodeId): void
+    {
     }
 }

--- a/src/CoreBundle/DataModel/BackendTreeNodeDataModel.php
+++ b/src/CoreBundle/DataModel/BackendTreeNodeDataModel.php
@@ -27,7 +27,7 @@ class BackendTreeNodeDataModel implements JsonSerializable
     /**
      * @var string
      */
-    private $furtherIcons = '';
+    private $furtherIconsHTML = '';
 
     /**
      * @var int
@@ -117,19 +117,19 @@ class BackendTreeNodeDataModel implements JsonSerializable
         $this->name = $name;
     }
 
-    public function getFurtherIcons(): string
+    public function getFurtherIconsHTML(): string
     {
-        return $this->furtherIcons;
+        return $this->furtherIconsHTML;
     }
 
-    public function setFurtherIcons(string $furtherIcons): void
+    public function setFurtherIconsHTML(string $furtherIconsHTML): void
     {
-        $this->furtherIcons = $furtherIcons;
+        $this->furtherIconsHTML = $furtherIconsHTML;
     }
 
-    public function addFurtherIcon(string $furtherIcon): void
+    public function addFurtherIconHTML(string $furtherIconHTML): void
     {
-        $this->furtherIcons .= $furtherIcon;
+        $this->furtherIconsHTML .= $furtherIconHTML;
     }
 
     public function getCmsIdent(): int
@@ -275,7 +275,7 @@ class BackendTreeNodeDataModel implements JsonSerializable
     {
         $jsTreeItem = [
             'id' => $this->id,
-            'text' => $this->furtherIcons . $this->name,
+            'text' => $this->furtherIconsHTML . $this->name,
             'type' => $this->type,
             'state' => [
                 'opened' => $this->opened,

--- a/src/CoreBundle/DataModel/BackendTreeNodeDataModel.php
+++ b/src/CoreBundle/DataModel/BackendTreeNodeDataModel.php
@@ -25,6 +25,11 @@ class BackendTreeNodeDataModel implements JsonSerializable
     private $name = '';
 
     /**
+     * @var string
+     */
+    private $furtherIcons = '';
+
+    /**
      * @var int
      */
     private $cmsIdent = '';
@@ -110,6 +115,21 @@ class BackendTreeNodeDataModel implements JsonSerializable
     public function setName(string $name): void
     {
         $this->name = $name;
+    }
+
+    public function getFurtherIcons(): string
+    {
+        return $this->furtherIcons;
+    }
+
+    public function setFurtherIcons(string $furtherIcons): void
+    {
+        $this->furtherIcons = $furtherIcons;
+    }
+
+    public function addFurtherIcon(string $furtherIcon): void
+    {
+        $this->furtherIcons .= $furtherIcon;
     }
 
     public function getCmsIdent(): int
@@ -255,7 +275,7 @@ class BackendTreeNodeDataModel implements JsonSerializable
     {
         $jsTreeItem = [
             'id' => $this->id,
-            'text' => $this->name,
+            'text' => $this->furtherIcons . $this->name,
             'type' => $this->type,
             'state' => [
                 'opened' => $this->opened,

--- a/src/CoreBundle/Field/FieldTreeNodePortalSelect.php
+++ b/src/CoreBundle/Field/FieldTreeNodePortalSelect.php
@@ -18,34 +18,24 @@ use TGlobal;
 /**
  * Allows the selection of only the portal root tree nodes (level 1 of tree).
  *
- * {@inheritDoc}
+ * {@inheritdoc}
  */
 class FieldTreeNodePortalSelect extends \TCMSFieldTreeNode
 {
-    /**
-     * @var string
-     */
-    protected $treeNodeSelectModulePagedef = 'navigationTreeSingleSelect';
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
     public function GetHTML()
     {
-        $this->translator = $this->getTranslator();
+        $translator = $this->getTranslator();
         $path = $this->_GetTreePath();
         $html = '<input type="hidden" id="'.TGlobal::OutHTML($this->name).'" name="'.TGlobal::OutHTML($this->name).'" value="'.TGlobal::OutHTML($this->data).'" />';
         $html .= '<div id="'.TGlobal::OutHTML($this->name).'_path">'.$path.'</div>';
         $html .= '<div class="cleardiv">&nbsp;</div>';
 
         $html .= \TCMSRender::DrawButton(
-            $this->translator->trans('chameleon_system_core.field_tree_node.assign_node'),
+            $translator->trans('chameleon_system_core.field_tree_node.assign_node'),
             "javascript:loadTreeNodePortalSelection('".TGlobal::OutJS($this->name)."');",
             'fas fa-check');
         $html .= \TCMSRender::DrawButton(
-            $this->translator->trans('chameleon_system_core.action.reset'),
+            $translator->trans('chameleon_system_core.action.reset'),
             "javascript:ResetTreeNodeSelection('".TGlobal::OutJS($this->name)."');",
             'fas fa-undo');
 

--- a/src/CoreBundle/Field/FieldTreeNodePortalSelect.php
+++ b/src/CoreBundle/Field/FieldTreeNodePortalSelect.php
@@ -11,6 +11,10 @@
 
 namespace ChameleonSystem\CoreBundle\Field;
 
+use ChameleonSystem\CoreBundle\ServiceLocator;
+use Symfony\Component\Translation\TranslatorInterface;
+use TGlobal;
+
 /**
  * Allows the selection of only the portal root tree nodes (level 1 of tree).
  *
@@ -19,13 +23,37 @@ namespace ChameleonSystem\CoreBundle\Field;
 class FieldTreeNodePortalSelect extends \TCMSFieldTreeNode
 {
     /**
-     * {@inheritDoc}
+     * @var string
      */
-    public function _GetOpenWindowJS()
-    {
-        $url = PATH_CMS_CONTROLLER.'?pagedef=navigationTreeSingleSelect&fieldName='.urlencode($this->name).'&id='.urlencode($this->data).'&portalSelect=1';
-        $js = "CreateModalIFrameDialogCloseButton('".\TGlobal::OutHTML($url)."')";
+    protected $treeNodeSelectModulePagedef = 'navigationTreeSingleSelect';
 
-        return $js;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function GetHTML()
+    {
+        $this->translator = $this->getTranslator();
+        $path = $this->_GetTreePath();
+        $html = '<input type="hidden" id="'.TGlobal::OutHTML($this->name).'" name="'.TGlobal::OutHTML($this->name).'" value="'.TGlobal::OutHTML($this->data).'" />';
+        $html .= '<div id="'.TGlobal::OutHTML($this->name).'_path">'.$path.'</div>';
+        $html .= '<div class="cleardiv">&nbsp;</div>';
+
+        $html .= \TCMSRender::DrawButton(
+            $this->translator->trans('chameleon_system_core.field_tree_node.assign_node'),
+            "javascript:loadTreeNodePortalSelection('".TGlobal::OutJS($this->name)."');",
+            'fas fa-check');
+        $html .= \TCMSRender::DrawButton(
+            $this->translator->trans('chameleon_system_core.action.reset'),
+            "javascript:ResetTreeNodeSelection('".TGlobal::OutJS($this->name)."');",
+            'fas fa-undo');
+
+        return $html;
+    }
+
+    private function getTranslator(): TranslatorInterface
+    {
+        return ServiceLocator::get('chameleon_system_core.translator');
     }
 }

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -947,9 +947,13 @@
             <argument id="database_connection" type="service"/>
             <argument id="event_dispatcher" type="service"/>
             <argument id="chameleon_system_core.util.input_filter" type="service"/>
-<!--            <argument id="chameleon_system_core.util.url" type="service"/>-->
+            <argument id="chameleon_system_core.util.url" type="service"/>
             <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
+            <argument id="chameleon_system_core.translator" type="service"/>
+            <argument id="chameleon_system_core.tools" type="service"/>
             <argument id="chameleon_system_core.global" type="service"/>
+            <argument type="service" id="chameleon_system_core.util.field_translation"/>
+            <argument type="service" id="chameleon_system_core.language_service"/>
             <argument id="request_stack" type="service"/>
             <argument id="chameleon_system_core.cache" type="service"/>
         </service>

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -933,9 +933,13 @@
             <argument id="database_connection" type="service"/>
             <argument id="event_dispatcher" type="service"/>
             <argument id="chameleon_system_core.util.input_filter" type="service"/>
+            <argument id="chameleon_system_core.util.url" type="service"/>
             <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
+            <argument id="chameleon_system_core.translator" type="service"/>
+            <argument id="chameleon_system_core.tools" type="service"/>
             <argument id="chameleon_system_core.global" type="service"/>
-            <argument id="chameleon_system_core.cache" type="service"/>
+            <argument type="service" id="chameleon_system_core.util.field_translation"/>
+            <argument type="service" id="chameleon_system_core.language_service"/>
         </service>
 
         <service id="chameleon_system_core.module.navigation_tree_single_select_wysiwyg" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelectWysiwyg\NavigationTreeSingleSelectWysiwyg" shared="false">
@@ -943,6 +947,7 @@
             <argument id="database_connection" type="service"/>
             <argument id="event_dispatcher" type="service"/>
             <argument id="chameleon_system_core.util.input_filter" type="service"/>
+<!--            <argument id="chameleon_system_core.util.url" type="service"/>-->
             <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
             <argument id="chameleon_system_core.global" type="service"/>
             <argument id="request_stack" type="service"/>

--- a/src/CoreBundle/Resources/public/javascript/jsTree/customStyles/style.css
+++ b/src/CoreBundle/Resources/public/javascript/jsTree/customStyles/style.css
@@ -15,8 +15,12 @@
     background: linear-gradient(to bottom, #beebff 0%, #a8e4ff 100%);
 }
 
-.treelegend .activeConnectedNode.primaryConnectedNode {
+.navigationTreeContainer .activeConnectedNode.primaryConnectedNodeOfCurrentPage .jstree-wholerow,
+.treelegend .activeConnectedNode.primaryConnectedNodeOfCurrentPage {
     color: #666;
+    background: #beebff;
+    background: -webkit-linear-gradient(top, #7ABAFF 0%, #7ABAFF 100%);
+    background: linear-gradient(to bottom, #7ABAFF 0%, #7ABAFF 100%);
 }
 
 .treelegend > div {

--- a/src/CoreBundle/Resources/public/javascript/jsTree/customStyles/style.css
+++ b/src/CoreBundle/Resources/public/javascript/jsTree/customStyles/style.css
@@ -7,36 +7,26 @@
     background: unset;
 }
 
-.navigationTreeContainer .node-hidden,
-.treelegend .page-hidden {
-    color: #848484;
-}
-
-.navigationTreeContainer .activeConnectedNode,
 .treelegend .activeConnectedNode {
     font-style: normal;
-    font-weight: bold;
-    color: #008000;
+    color: #23282c;
+    background: #beebff;
+    background: -webkit-linear-gradient(top, #beebff 0%, #a8e4ff 100%);
+    background: linear-gradient(to bottom, #beebff 0%, #a8e4ff 100%);
 }
 
-.navigationTreeContainer .otherConnectedNode,
-.treelegend .otherConnectedNode {
-    font-style: normal;
-    color: #008000;
-}
-
-.navigationTreeContainer .activeConnectedNode.primaryConnectedNode,
 .treelegend .activeConnectedNode.primaryConnectedNode {
-    font-style: normal;
-    color: #005588;
-}
-.treelegend {
-    display: table-cell;
-    width: 350px;
+    color: #666;
 }
 
-.treelegend .nodeIndicatorIcon {
-    padding-left: 20px;
+.treelegend > div {
+    display: flex;
+    align-items: flex-start;
+}
+
+.treelegend > div .nodeIndicatorIcon {
+    width: 2.5em;
+    text-align: center;
 }
 
 .treelegend .rightClickMenuDisabled {

--- a/src/CoreBundle/Resources/public/javascript/navigationTree.js
+++ b/src/CoreBundle/Resources/public/javascript/navigationTree.js
@@ -103,7 +103,7 @@ $(document).ready(function () {
             },
             "types": {
                 "default": {
-                    "icon": "fas fa-folder-open"
+                    "icon": "fas fa-genderless"
                 },
                 "folder": {
                     "icon": "fas fa-folder-open"
@@ -114,9 +114,8 @@ $(document).ready(function () {
                 "folderRootRestrictedMenu": {
                     "icon": "fas fa-folder-open"
                 },
-                "folderWithPage": {
-                    "icon": "fas fa-folder-open",
-                    "check_node": false
+                "noPage": {
+                    "icon": "fas fa-genderless"
                 },
                 "page": {
                     "icon": "far fa-file"
@@ -124,11 +123,11 @@ $(document).ready(function () {
                 "locked": {
                     "icon": "fas fa-lock"
                 },
-                "pageHidden": {
+                "extranetpageHidden": {
                     "icon": "far fa-eye-slash"
                 },
                 "nodeHidden": {
-                    "icon": "far fa-eye-slash"
+                    "icon": "fas fa-eye-slash"
                 },
                 "externalLink": {
                     "icon": "fas fa-external-link-alt"
@@ -159,23 +158,19 @@ $(document).ready(function () {
             },
             "types": {
                 "default": {
-                    "icon": "fas fa-folder-open"
+                    "icon": "fas fa-genderless"
                 },
                 "folder": {
-                    "icon": "fas fa-folder-open",
-                    "check_node": false
+                    "icon": "fas fa-folder-open"
                 },
                 "folderRestrictedMenu": {
-                    "icon": "fas fa-folder-open",
-                    "check_node": false
+                    "icon": "fas fa-folder-open"
                 },
                 "folderRootRestrictedMenu": {
-                    "icon": "fas fa-folder-open",
-                    "check_node": false
+                    "icon": "fas fa-folder-open"
                 },
-                "folderWithPage": {
-                    "icon": "fas fa-folder-open",
-                    "check_node": false
+                "noPage": {
+                    "icon": "fas fa-genderless"
                 },
                 "page": {
                     "icon": "far fa-file"
@@ -183,11 +178,11 @@ $(document).ready(function () {
                 "locked": {
                     "icon": "fas fa-lock"
                 },
-                "pageHidden": {
+                "extranetpageHidden": {
                     "icon": "far fa-eye-slash"
                 },
                 "nodeHidden": {
-                    "icon": "far fa-eye-slash"
+                    "icon": "fas fa-eye-slash"
                 },
                 "externalLink": {
                     "icon": "fas fa-external-link-alt"

--- a/src/CoreBundle/Resources/public/javascript/navigationTree.js
+++ b/src/CoreBundle/Resources/public/javascript/navigationTree.js
@@ -51,10 +51,10 @@ $(document).ready(function () {
             "plugins":[ "types", "wholerow", "changed", "checkbox" ]
         })
         .on("select_node.jstree", function (e, data) {
-            updatePrimaryNodeOfCurrentPage(data.node.id);
+            updateCurrentPageOrPortal(data.node.id);
         })
         .on("deselect_node.jstree", function (e, data) {
-            updatePrimaryNodeOfCurrentPage('');
+            updateCurrentPageOrPortal('');
         });
 
 
@@ -234,12 +234,12 @@ $(document).ready(function () {
         });
 });
 
-function updatePrimaryNodeOfCurrentPage(newNodeId) {
+function updateCurrentPageOrPortal(newNodeId) {
     let url = navTreeDataContainer.data('update-selection-url') + '&sRestriction=' + newNodeId + '&nodeId=' + newNodeId;
-    GetAjaxCallTransparent(url, updatePrimaryNodeSuccess);
+    GetAjaxCallTransparent(url, updateCurrentPageOrPortalSuccess);
 }
 
-function updatePrimaryNodeSuccess(nodeId, responseMessage) {
+function updateCurrentPageOrPortalSuccess(nodeId, responseMessage) {
     if ('success' === responseMessage) {
         const fieldName = navTreeDataContainer.data('field-name');
         chooseTreeNode(fieldName, nodeId);

--- a/src/CoreBundle/Resources/public/javascript/navigationTree.js
+++ b/src/CoreBundle/Resources/public/javascript/navigationTree.js
@@ -1,21 +1,47 @@
 $(document).ready(function () {
 
+    let singleNavTreeDataContainer = $("#singleNavigationTreeDataContainer");
+
     $("#singleTreeNodeSelect")
         .jstree({
             "core":{
                 "multiple": false,
-                "open_all": true
+                "open_all": true,
+                "data": {
+                    "url": singleNavTreeDataContainer.data('tree-nodes-ajax-url'),
+                    "data": function(node) {
+                        return {
+                            'id' : node.id
+                        };
+                    }
+                },
+                "check_callback" : true
             },
             "types": {
                 "default": {
-                    "icon": ""
+                    "icon": "fas fa-genderless"
                 },
                 "folder": {
                     "icon": "fas fa-folder-open",
                     "check_node": false
                 },
+                "noPage": {
+                    "icon": "fas fa-genderless"
+                },
                 "page": {
                     "icon": "far fa-file"
+                },
+                "locked": {
+                    "icon": "fas fa-lock"
+                },
+                "extranetpageHidden": {
+                    "icon": "far fa-eye-slash"
+                },
+                "nodeHidden": {
+                    "icon": "fas fa-eye-slash"
+                },
+                "externalLink": {
+                    "icon": "fas fa-external-link-alt"
                 }
             },
             "checkbox": {
@@ -23,23 +49,27 @@ $(document).ready(function () {
                 "cascade": "none"
             },
             "plugins":[ "types", "wholerow", "changed", "checkbox" ]
+        })
+        .on("select_node.jstree", function (e, data) {
+            updatePrimaryNodeOfCurrentPage(data.node.id);
+        })
+        .on("deselect_node.jstree", function (e, data) {
+            updatePrimaryNodeOfCurrentPage('');
         });
 
+    function updatePrimaryNodeOfCurrentPage(newNodeId) {
+        var url = singleNavTreeDataContainer.data('update-primary-node-of-page-url') + '&sRestriction=' + newNodeId + '&nodeId=' + newNodeId;
+        GetAjaxCallTransparent(url, updatePrimaryNodeSuccess);
+    }
 
-    $('.jstree-selection').click(function () {
-        var selectedItem = $("#singleTreeNodeSelect").jstree('get_selected');
-
-        if (selectedItem.length > 0) {
-            var singleSelection = $('#'+selectedItem[0]);
-            var fieldName = singleSelection.data('selection').fieldName;
-            var newId = singleSelection.data('selection').nodeId;
-            chooseTreeNode(fieldName, newId);
+    function updatePrimaryNodeSuccess(nodeId, responseMessage) {
+        if ('success' === responseMessage) {
+            let fieldName = singleNavTreeDataContainer.data('field-name');
+            chooseTreeNode(fieldName, nodeId);
+            parent.CloseModalIFrameDialog();
         }
-    });
+    }
 
-    $('.jstree-exit').click(function () {
-        parent.CloseModalIFrameDialog();
-    });
 
     var singleTreeNodeSelectWysiwyg = $("#singleTreeNodeSelectWysiwyg");
     singleTreeNodeSelectWysiwyg.jstree({
@@ -218,7 +248,10 @@ $(document).ready(function () {
  */
 function chooseTreeNode(fieldName, newId) {
     parent.$('#' + fieldName).val(newId);
-    var newPath = $('#' + fieldName + '_tmp_path_' + newId).html();
+    var newPath = "";
+    if (newId !== "") {
+        newPath = $('#' + fieldName + '_tmp_path_' + newId).html();
+    }
     parent.$('#' + fieldName + '_path').html(newPath);
     parent.CloseModalIFrameDialog();
 }
@@ -440,7 +473,7 @@ function connectPageOnSelect(nodeId) {
 function connectPageSuccess(nodeId, responseMessage) {
     if ('success' === responseMessage) {
         //don't do a refresh here, because refresh_node triggers "selected" again from state
-        $(".navigationTreeContainer.jstree #"+nodeId+"_anchor").addClass('activeConnectedNode');
+        $(".navigationTreeContainer.jstree #"+nodeId).addClass('activeConnectedNode');
     } else {
         $(".navigationTreeContainer.jstree #" + nodeId + "_anchor").addClass('jstree-clicked');
     }
@@ -455,7 +488,7 @@ function disconnectPageOnDeselect(nodeId) {
 function disconnectPageSuccess(nodeId, responseMessage) {
     if ('success' === responseMessage) {
         //don't do a refresh here, because refresh_node triggers "selected" again from state
-        $(".navigationTreeContainer.jstree #" + nodeId + "_anchor").removeClass('activeConnectedNode');
+        $(".navigationTreeContainer.jstree #" + nodeId).removeClass('activeConnectedNode');
     } else {
         $(".navigationTreeContainer.jstree #" + nodeId + "_anchor").addClass('jstree-clicked');
     }

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -229,23 +229,23 @@ function changeColorPreview(previewDivID, hex) {
 }
 
 function loadTreeNodePortalSelection(fieldName) {
-    var portalId = document.cmseditform.id.value;
+    let portalId = document.cmseditform.id.value;
     let selectedPortalNodeId = $('#'+fieldName).val();
 
     if (portalId !== '0' && portalId !== '') {
-        let url = window.location.pathname + '?pagedef=navigationTreeSingleSelect&portalSelectMode=portalSelect&fieldName='+fieldName+'&id='+selectedPortalNodeId+'&portalId='+portalId;
+        let url = window.location.pathname + '?pagedef=navigationTreeSingleSelect' + '&portalSelectMode=portalSelect' + '&fieldName='+fieldName+'&id='+selectedPortalNodeId+'&portalId='+portalId;
         CreateModalIFrameDialogCloseButton(url, 0, 0);
     } else {
         toasterMessage(CHAMELEON.CORE.i18n.Translate('chameleon_system_core.js.error_portal_required'), 'WARNING');
     }
 }
 
-function loadHomeTreeNodeSelection(fieldName, id) {
-    //var portalID = document.getElementById('main_node_tree').value;
-    var portalID = document.cmseditform.id.value;
+function loadHomeTreeNodeSelection(fieldName) {
+    let portalId = document.cmseditform.id.value;
+    let selectedHomeNodeId = $('#'+fieldName).val();
 
-    if (portalID !== '0' && portalID !== '') {
-        CreateModalIFrameDialogCloseButton(window.location.pathname + '?pagedef=navigationTreeSingleSelect&id=' + id + '&fieldName=' + fieldName + '&portalID=' + portalID + '&portalSelectMode=portalHomePage', 400, 500);
+    if (portalId !== '0' && portalId !== '') {
+        CreateModalIFrameDialogCloseButton(window.location.pathname + '?pagedef=navigationTreeSingleSelect' + '&portalSelectMode=portalHomePage' + '&fieldName=' + fieldName + '&id=' + selectedHomeNodeId + '&portalId=' + portalId, 0, 0);
     } else {
         toasterMessage(CHAMELEON.CORE.i18n.Translate('chameleon_system_core.js.error_portal_required'), 'WARNING');
     }

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -228,12 +228,24 @@ function changeColorPreview(previewDivID, hex) {
     }
 }
 
+function loadTreeNodePortalSelection(fieldName) {
+    var portalId = document.cmseditform.id.value;
+    let selectedPortalNodeId = $('#'+fieldName).val();
+
+    if (portalId !== '0' && portalId !== '') {
+        let url = window.location.pathname + '?pagedef=navigationTreeSingleSelect&portalSelectMode=portalSelect&fieldName='+fieldName+'&id='+selectedPortalNodeId+'&portalId='+portalId;
+        CreateModalIFrameDialogCloseButton(url, 0, 0);
+    } else {
+        toasterMessage(CHAMELEON.CORE.i18n.Translate('chameleon_system_core.js.error_portal_required'), 'WARNING');
+    }
+}
+
 function loadHomeTreeNodeSelection(fieldName, id) {
     //var portalID = document.getElementById('main_node_tree').value;
     var portalID = document.cmseditform.id.value;
 
     if (portalID !== '0' && portalID !== '') {
-        CreateModalIFrameDialogCloseButton(window.location.pathname + '?pagedef=navigationTreeSingleSelect&id=' + id + '&fieldName=' + fieldName + '&portalID=' + portalID, 400, 500);
+        CreateModalIFrameDialogCloseButton(window.location.pathname + '?pagedef=navigationTreeSingleSelect&id=' + id + '&fieldName=' + fieldName + '&portalID=' + portalID + '&portalSelectMode=portalHomePage', 400, 500);
     } else {
         toasterMessage(CHAMELEON.CORE.i18n.Translate('chameleon_system_core.js.error_portal_required'), 'WARNING');
     }

--- a/src/CoreBundle/Resources/translations/admin.de.xliff
+++ b/src/CoreBundle/Resources/translations/admin.de.xliff
@@ -1114,7 +1114,7 @@
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
                 <target>Navigationspunkt versteckt</target>
-                <note>@deprecated since 6.3.9 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
+                <note>@deprecated since 6.3.10 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
             </trans-unit>
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>

--- a/src/CoreBundle/Resources/translations/admin.de.xliff
+++ b/src/CoreBundle/Resources/translations/admin.de.xliff
@@ -1111,6 +1111,11 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_folder</source>
                 <target>Ordner / Verzeichnis</target>
             </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
+                <target>Navigationspunkt versteckt</target>
+                <note>@deprecated since 6.3.9 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
+            </trans-unit>
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>
                 <target>Navigationspunkt versteckt</target>

--- a/src/CoreBundle/Resources/translations/admin.de.xliff
+++ b/src/CoreBundle/Resources/translations/admin.de.xliff
@@ -1106,6 +1106,20 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_active_further_node_of_page</source>
                 <target>Aktiver weiterer Navigationspunkt dieser Seite</target>
             </trans-unit>
+
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_folder">
+                <source>chameleon_system_core.cms_module_page_tree.legend_folder</source>
+                <target>Ordner / Verzeichnis</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>
+                <target>Navigationspunkt versteckt</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_external_link">
+                <source>chameleon_system_core.cms_module_page_tree.legend_external_link</source>
+                <target>Link auf externe Website</target>
+            </trans-unit>
+
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_has_no_page">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_has_no_page</source>
                 <target>Navigationspunkt ohne verknüpfte Seite</target>
@@ -1118,15 +1132,10 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page</source>
                 <target>Navigationspunkt mit zugriffsbeschränkter Seite</target>
             </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
-                <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
-                <target>Navigationspunkt versteckt</target>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_extranetpage_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_extranetpage_hidden</source>
+                <target>Zugriffsbeschränkte Seite, in der Navigation versteckt</target>
             </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_external_link">
-                <source>chameleon_system_core.cms_module_page_tree.legend_external_link</source>
-                <target>Link auf externe Website</target>
-            </trans-unit>
-
 
             <trans-unit id="chameleon_system_core.cms_module_media_local_import.error_path_not_found">
                 <source>chameleon_system_core.cms_module_media_local_import.error_path_not_found</source>

--- a/src/CoreBundle/Resources/translations/admin.en.xliff
+++ b/src/CoreBundle/Resources/translations/admin.en.xliff
@@ -1088,9 +1088,9 @@
                 <target>Edit node</target>
                 <note>@deprecated since 6.3.8 - no longer used.</note>
             </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page">
-                <source>chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page</source>
-                <target>Navigation node with restricted access page</target>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page">
+                <source>chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page</source>
+                <target>Page has connected navigation node</target>
                 <note>@deprecated since 6.3.8 - no longer used.</note>
             </trans-unit>
 
@@ -1106,6 +1106,20 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_active_further_node_of_page</source>
                 <target>Active further navigation node of this page</target>
             </trans-unit>
+
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_folder">
+                <source>chameleon_system_core.cms_module_page_tree.legend_folder</source>
+                <target>Folder</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>
+                <target>Navigation node hidden</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_external_link">
+                <source>chameleon_system_core.cms_module_page_tree.legend_external_link</source>
+                <target>Link to external page</target>
+            </trans-unit>
+
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_has_no_page">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_has_no_page</source>
                 <target>Navigation node without connected page</target>
@@ -1114,17 +1128,14 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_has_connected_pages</source>
                 <target>Navigation node with connected page</target>
             </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page">
-                <source>chameleon_system_core.cms_module_page_tree.legend_connected_to_selected_page</source>
-                <target>Page has connected navigation node</target>
+
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page">
+                <source>chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page</source>
+                <target>Navigation node with restricted access page</target>
             </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
-                <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
-                <target>Navigation node hidden</target>
-            </trans-unit>
-            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_external_link">
-                <source>chameleon_system_core.cms_module_page_tree.legend_external_link</source>
-                <target>Link to external page</target>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_extranetpage_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_extranetpage_hidden</source>
+                <target>Access restricted page, hidden in the navigation</target>
             </trans-unit>
 
 

--- a/src/CoreBundle/Resources/translations/admin.en.xliff
+++ b/src/CoreBundle/Resources/translations/admin.en.xliff
@@ -1111,6 +1111,11 @@
                 <source>chameleon_system_core.cms_module_page_tree.legend_folder</source>
                 <target>Folder</target>
             </trans-unit>
+            <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
+                <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
+                <target>Navigation node hidden</target>
+                <note>@deprecated since 6.3.9 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
+            </trans-unit>
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>
                 <target>Navigation node hidden</target>

--- a/src/CoreBundle/Resources/translations/admin.en.xliff
+++ b/src/CoreBundle/Resources/translations/admin.en.xliff
@@ -1114,7 +1114,7 @@
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_hidden</source>
                 <target>Navigation node hidden</target>
-                <note>@deprecated since 6.3.9 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
+                <note>@deprecated since 6.3.10 - no longer used, use "chameleon_system_core.cms_module_page_tree.legend_node_hidden" instead</note>
             </trans-unit>
             <trans-unit id="chameleon_system_core.cms_module_page_tree.legend_node_hidden">
                 <source>chameleon_system_core.cms_module_page_tree.legend_node_hidden</source>

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
@@ -10,7 +10,8 @@
 {% endif %}
         <div class="row m-0">
             <div class="col-12 col-md-6 col-xl-8">
-                <div id="navigationTreeDataContainer"
+                <div id="navigationTreeDataContainer" class="mb-4"
+                     data-field-name = "{{ fieldName }}"
                      data-tree-nodes-ajax-url = "{{ treeNodesAjaxUrl | raw }}"
                      data-open-page-connection-list-url = "{{ openPageConnectionListUrl | raw }}"
                      data-open-page-editor-url = "{{ openPageEditorUrl | raw }}"
@@ -86,4 +87,6 @@
     </div>
 </div>
 {% endif %}
+
+{{ breadcrumbStorageHTML | raw }}
 

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
@@ -32,7 +32,7 @@
                     <h5>{{ 'chameleon_system_core.cms_module_page_tree.legend_header' | trans }}</h5>
 
                     {% if noAssignDialog == false %}
-                        <div class="activeConnectedNode primaryConnectedNode">
+                        <div class="activeConnectedNode primaryConnectedNodeOfCurrentPage">
                             <div class="nodeIndicatorIcon"><i class="far fa-check-square"></i></div>
                             <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_active_main_node_of_page' | trans }}</div>
                         </div>

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTree/standard.html.twig
@@ -29,47 +29,53 @@
             </div>
             <div class="col-12 col-md-6 col-xl-4 justify-content-end mt-4 mt-md-0">
                 <div class="treelegend">
-                    <h5>
-                        <span class="nodeIndicatorIcon"></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_header' | trans }}</span>
-                    </h5>
+                    <h5>{{ 'chameleon_system_core.cms_module_page_tree.legend_header' | trans }}</h5>
 
                     {% if noAssignDialog == false %}
                         <div class="activeConnectedNode primaryConnectedNode">
-                            <span class="nodeIndicatorIcon"></span>
-                            <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_active_main_node_of_page' | trans }}</span>
+                            <div class="nodeIndicatorIcon"><i class="far fa-check-square"></i></div>
+                            <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_active_main_node_of_page' | trans }}</div>
                         </div>
-
-
                         <div class="activeConnectedNode">
-                            <span class="nodeIndicatorIcon"></span>
-                            <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_active_further_node_of_page' | trans }}</span>
+                            <div class="nodeIndicatorIcon"><i class="far fa-check-square"></i></div>
+                            <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_active_further_node_of_page' | trans }}</div>
                         </div>
+                        <br>
                     {% endif %}
 
                     <div class="text">
-                        <span class="nodeIndicatorIcon"></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_node_has_no_page' | trans }}</span>
-                    </div>
-
-                    <div class="otherConnectedNode">
-                        <span class="nodeIndicatorIcon"></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_has_connected_pages' | trans }}</span>
-                    </div>
-
-                    <div class="restrictedPage">
-                        <span class="nodeIndicatorIcon iconRestricted"><i class="fas fa-lock"></i></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page' | trans }}</span>
+                        <div class="nodeIndicatorIcon"><i class="fas fa-folder-open"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_folder' | trans }}</div>
                     </div>
 
                     <div class="node-hidden">
-                        <span class="nodeIndicatorIcon iconHidden"><i class="far fa-eye-slash"></i></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_hidden' | trans }}</span>
+                        <div class="nodeIndicatorIcon iconHidden"><i class="fas fa-eye-slash"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_node_hidden' | trans }}</div>
                     </div>
 
                     <div class="legendLine">
-                        <span class="nodeIndicatorIcon iconExternalLink"><i class="fas fa-external-link-alt"></i></span>
-                        <span>{{ 'chameleon_system_core.cms_module_page_tree.legend_external_link' | trans }}</span>
+                        <div class="nodeIndicatorIcon iconExternalLink"><i class="fas fa-external-link-alt"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_external_link' | trans }}</div>
+                    </div>
+
+                    <div class="text">
+                        <div class="nodeIndicatorIcon"><i class="fas fa-genderless"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_node_has_no_page' | trans }}</div>
+                    </div>
+
+                    <div class="otherConnectedNode">
+                        <div class="nodeIndicatorIcon"><i class="far fa-file"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_has_connected_pages' | trans }}</div>
+                    </div>
+
+                    <div class="restrictedPage">
+                        <div class="nodeIndicatorIcon iconRestricted"><i class="fas fa-user-lock"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_connected_to_protected_page' | trans }}</div>
+                    </div>
+
+                    <div class="extranetpage-hidden">
+                        <div class="nodeIndicatorIcon iconHidden"><i class="far fa-eye-slash"></i></div>
+                        <div>{{ 'chameleon_system_core.cms_module_page_tree.legend_extranetpage_hidden' | trans }}</div>
                     </div>
                 </div>
 

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
@@ -9,4 +9,4 @@
     <div id="singleTreeNodeSelect" class="navigationTreeContainer"></div>
 </div>
 
-{{ breadcrumbStorageHTML | raw }}
+{{ pageBreadcrumbsHTML | raw }}

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
@@ -1,9 +1,9 @@
 {# @var treeNodes \ChameleonSystem\CoreBundle\DataModel\BackendTreeNodeDataModel #}
 
-<div id="singleNavigationTreeDataContainer"
+<div id="navigationTreeDataContainer" class="mb-4"
      data-field-name = "{{ fieldName }}"
      data-tree-nodes-ajax-url = "{{ treeNodesAjaxUrl | raw }}"
-     data-update-primary-node-of-page-url = "{{ updatePrimaryNodeUrl | raw }}" >
+     data-update-selection-url = "{{ updateSelectionUrl | raw }}" >
 
     <div id="singleTreeNodeSelect" class="navigationTreeContainer"></div>
 </div>

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
@@ -1,43 +1,11 @@
 {# @var treeNodes \ChameleonSystem\CoreBundle\DataModel\BackendTreeNodeDataModel #}
 
-{% if level == 0 %}
+<div id="singleNavigationTreeDataContainer"
+     data-field-name = "{{ fieldName }}"
+     data-tree-nodes-ajax-url = "{{ treeNodesAjaxUrl | raw }}"
+     data-update-primary-node-of-page-url = "{{ updatePrimaryNodeUrl | raw }}" >
 
-    <button class="btn btn-success mb-4 jstree-selection">{{ 'chameleon_system_core.navigation_tree.confirm_selection' | trans }}</button>
-    <button class="btn btn-danger mb-4 jstree-exit">{{ 'chameleon_system_core.navigation_tree.cancel_selection' | trans }}</button>
+    <div id="singleTreeNodeSelect" class="navigationTreeContainer"></div>
+</div>
 
-    <div id="singleTreeNodeSelect">
-        <ul>
-            {% endif %}
-
-            {% if treeNodes.name != "" %}
-                {% set isNodeCheckable = true %}
-                {% if (not isPortalSelectMode and level <= 1) or (isPortalSelectMode and level != 1) %}
-                    {% set isNodeCheckable = false %}
-                {% endif %}
-
-                <li id="node{{ treeNodes.cmsIdent }}" class="{% if isNodeCheckable == false %}no-checkbox{% endif %}{% if level == 0 %} jstree-open{% endif %}"
-                    data-jstree="{&quot;type&quot;: &quot;{% if treeNodes.children | length > 0 %}folder{% else %}page{% endif %}&quot;{% if isNodeCheckable == false %}, &quot;disabled&quot;: true{% endif %}}"
-                    data-selection="{&quot;fieldName&quot;: &quot;{{ fieldName }}&quot;, &quot;nodeId&quot;: &quot;{{ treeNodes.id }}&quot;}" >
-
-                    <a href="#"{% if activeId == treeNodes.id %} class="jstree-clicked"{% endif %}>
-                        {{ treeNodes.name }}
-                    </a>
-
-                    {% if treeNodes.children | length > 0 %}
-                        <ul>
-                            {% for child in treeNodes.children %}
-                                {% include _self with {'treeNodes': child, 'level': level+1, 'path': path, 'pathComplete': pathComplete} %}
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                </li>
-            {% endif %}
-
-            {% if level == 0 %}
-        </ul>
-    </div>
-
-    <button class="btn btn-success mt-4 jstree-selection">{{ 'chameleon_system_core.navigation_tree.confirm_selection' | trans }}</button>
-    <button class="btn btn-danger mt-4 jstree-exit">{{ 'chameleon_system_core.navigation_tree.cancel_selection' | trans }}</button>
-    {{ treePathHTML | raw }}
-{% endif %}
+{{ breadcrumbStorageHTML | raw }}

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelect/standard.html.twig
@@ -2,6 +2,7 @@
 
 <div id="navigationTreeDataContainer" class="mb-4"
      data-field-name = "{{ fieldName }}"
+     data-portal-select-mode = "{{ portalSelectMode }}"
      data-tree-nodes-ajax-url = "{{ treeNodesAjaxUrl | raw }}"
      data-update-selection-url = "{{ updateSelectionUrl | raw }}" >
 

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelectWysiwyg/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelectWysiwyg/standard.html.twig
@@ -1,41 +1,12 @@
 {# @var treeNodes \ChameleonSystem\CoreBundle\DataModel\BackendTreeNodeDataModel #}
 
-{% if level == 0 %}
+<div id="navigationTreeDataContainer" class="p-4"
+     data-field-name = "{{ fieldName }}"
+     data-tree-nodes-ajax-url = "{{ treeNodesAjaxUrl | raw }}"
+     data-ckeditorfuncnum="{{ CKEditorFuncNum }}">
 
-    <div class="p-4">
-        <button class="btn btn-success mb-4 jstree-selection-wysiwyg">{{ 'chameleon_system_core.navigation_tree.confirm_selection' | trans }}</button>
-        <button class="btn btn-danger mb-4 jstree-exit-wysiwyg">{{ 'chameleon_system_core.navigation_tree.cancel_selection' | trans }}</button>
+    <div id="singleTreeNodeSelectWysiwyg" class="navigationTreeContainer"></div>
+</div>
 
-        <div id="singleTreeNodeSelectWysiwyg" data-ckeditorfuncnum="{{ CKEditorFuncNum }}">
-            <ul>
-                {% endif %}
+{{ breadcrumbStorageHTML | raw }}
 
-                {% if treeNodes.name != "" %}
-                    <li id="node{{ treeNodes.cmsIdent }}" class="{% if level <=1 %}no-checkbox{% endif %}{% if level == 0 %} jstree-open{% endif %}"
-                        data-jstree="{&quot;type&quot;: &quot;{% if treeNodes.children | length > 0 %}folder{% else %}page{% endif %}&quot;{% if level <= 1 %}, &quot;disabled&quot;: true{% endif %}}"
-                        data-selection="{&quot;fieldName&quot;: &quot;{{ fieldName }}&quot;, &quot;nodeId&quot;: &quot;{{ treeNodes.id }}&quot;, &quot;connectedPageId&quot;: &quot;{{ treeNodes.connectedPageId }}&quot;}" >
-
-                        <a href="#"{% if activeId == treeNodes.id %} class="jstree-clicked"{% endif %}>
-                            {{ treeNodes.name }}
-                        </a>
-
-                        {% if treeNodes.children | length > 0 %}
-                            <ul>
-                                {% for child in treeNodes.children %}
-                                    {% include _self with {'treeNodes': child, 'level': level+1, 'path': path, 'pathComplete': pathComplete} %}
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                    </li>
-                {% endif %}
-
-                {% if level == 0 %}
-            </ul>
-        </div>
-
-        <button class="btn btn-success mt-4 jstree-selection-wysiwyg">{{ 'chameleon_system_core.navigation_tree.confirm_selection' | trans }}</button>
-        <button class="btn btn-danger mt-4 jstree-exit-wysiwyg">{{ 'chameleon_system_core.navigation_tree.cancel_selection' | trans }}</button>
-        {{ treePathHTML | raw }}
-    </div>
-
-{% endif %}

--- a/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelectWysiwyg/standard.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/NavigationTreeSingleSelectWysiwyg/standard.html.twig
@@ -8,5 +8,5 @@
     <div id="singleTreeNodeSelectWysiwyg" class="navigationTreeContainer"></div>
 </div>
 
-{{ breadcrumbStorageHTML | raw }}
+{{ pageBreadcrumbsHTML | raw }}
 

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
@@ -333,6 +333,7 @@ class TCMSFieldPageTreeNode extends TCMSFieldTreeNode
                 'rootID' => TCMSTreeNode::TREE_ROOT_ID,
                 'id' => $this->oTableRow->id,
                 'isInIframe' => '1',
+                'fieldName' => $this->name,
                 'primaryTreeNodeId' => $this->oTableRow->fieldPrimaryTreeIdHidden
             ], '', '&');
     }

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPageTreeNode.class.php
@@ -291,7 +291,7 @@ class TCMSFieldPageTreeNode extends TCMSFieldTreeNode
               $('#tooltipcms_portal_id_content').parent('td').prepend('<input type=\"hidden\" name=\"cms_portal_id\" id=\"cms_portal_id\" value=\"' + portalID + '\" />' + portalName);
               $('#tooltipcms_portal_id_content').siblings('.switchToRecordBox').remove();
             }
-            CreateModalIFrameDialogCloseButton('".PATH_CMS_CONTROLLER."?pagedef=".TGlobal::OutJS($this->treeNodeSelectModulePagedef)."&id=' + id + '&fieldName=' + fieldName + '&portalID=' + portalID);
+            CreateModalIFrameDialogCloseButton('".PATH_CMS_CONTROLLER."?pagedef=".TGlobal::OutJS($this->treeNodeSelectModulePagedef)."&id=' + id + '&fieldName=' + fieldName + '&portalID=' + portalID + '&currentPageId=".$this->oTableRow->id."', 0, 0, '".TGlobal::Translate('chameleon_system_core.field_page_tree_node.assign_primary_node')."');
           } else {
             toasterMessage('".TGlobal::Translate('chameleon_system_core.field_page_tree_node.error_no_portal_selected')."','WARNING');
           }

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPortalHomeTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPortalHomeTreeNode.class.php
@@ -18,7 +18,7 @@ class TCMSFieldPortalHomeTreeNode extends TCMSFieldTreeNode
 {
     public function _GetOpenWindowJS()
     {
-        $js = "loadHomeTreeNodeSelection('".TGlobal::OutHTML($this->name)."','".TGlobal::OutHTML($this->data)."')";
+        $js = "loadHomeTreeNodeSelection('".TGlobal::OutHTML($this->name)."')";
 
         return $js;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        |  features / 6.3.x 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#572
| License       | MIT


- NavigationTree and NavigationTreeSingleSelect with several status icons
- Pages: Assign primary node and assign further navigation nodes: only those nodes are assignable, that haven't any assigned pages yet.
- Save records on select / deselect
- Update Breadcrumb on select / deselect
- First, NavigationTreeSingleSelect built an HTML structure, now it works with a json object that is passed to jstree via ajax.
- The buttons "Apply selection" and "Cancel" were removed, instead a change of the selection is now immediately saved via ajax and the window is closed.
- "NavigationTreeSingleSelectWysiwyg" is an extension of "NavigationTreeSingleSelect".
All own methods had to be adapted to the json-method, furthermore all nodes must be selectable, no matter if they have a page or not.
- NavigationTreeSingleSelect at portals
    - assign portal record to a portal
    - assign a start page for the portal
    - assign a 404 page for the portal
    Depending on the case, different navigation levels are selectable. 
    Automatic saving of the portal data record after selection
- Every new call of jstree must contain the current field data, even if the page is not reloaded from the server in the meantime. To do this, the field(s) must first be read out by JS every time the iframe is loaded and not initially transferred from the server.
