### PR TITLE
ref #595: add missing target table definition to   field 'parent' in …

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1592409240.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1592409240.inc.php
@@ -1,0 +1,26 @@
+<h1>Build #1592409240</h1>
+<h2>Date: 2020-06-17</h2>
+<div class="changelog">
+    - ref #595 add missing target table config to document tree parent field
+</div>
+<?php
+$documentTreeParentFieldId = TCMSLogChange::GetTableFieldId(
+    TCMSLogChange::GetTableId('cms_document_tree'),
+    'parent_id'
+);
+$query = "SELECT `fieldtype_config` FROM `cms_field_conf` WHERE `id` = :id";
+$fieldConfig = TCMSLogChange::getDatabaseConnection()->fetchColumn($query, ['id' => $documentTreeParentFieldId]);
+if (false === stripos($fieldConfig, 'connectedTableName')) {
+    $data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+        ->setFields(
+            [
+                'fieldtype_config' => 'connectedTableName=cms_document_tree',
+            ]
+        )
+        ->setWhereEquals(
+            [
+                'id' => $documentTreeParentFieldId,
+            ]
+        );
+    TCMSLogChange::update(__LINE__, $data);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#595
| License       | MIT

fix definition of the parent field in the cms_document_tree table