### PR TITLE
Feature/591 filter unwanted log data

### DIFF
--- a/src/CoreBundle/Resources/config/version.inc.php
+++ b/src/CoreBundle/Resources/config/version.inc.php
@@ -1,4 +1,4 @@
 <?php
 
 define('CMS_VERSION_MAJOR', '6');
-define('CMS_VERSION_MINOR', '3.9.2');
+define('CMS_VERSION_MINOR', '3.10');

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1729,14 +1729,6 @@ class TCMSTableEditorEndPoint
             }
         }
 
-        if(null !== $this->sId) {
-            $dataForChangeRecorder = $this->filterUnchangedFields(
-                $editablePostFields,
-                $tableName,
-                $this->sId
-            );
-        }
-
         if ($isFirst) {
             return false;
         } // no changes made... no fields to write
@@ -1795,6 +1787,14 @@ class TCMSTableEditorEndPoint
             /** @var  $migrationRecorderStateHandler MigrationRecorderStateHandler */
             $migrationRecorderStateHandler = ServiceLocator::get('chameleon_system_database_migration.recorder.migration_recorder_state_handler');
             if ($this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive() && count($dataForChangeRecorder) >= 1) {
+                if (null !== $this->sId) {
+                    $dataForChangeRecorder = $this->filterUnchangedFields(
+                        $editablePostFields,
+                        $tableName,
+                        $this->sId
+                    );
+                }
+                
                 $this->writePostWriteLogChangeData($bIsUpdateCall, $dataForChangeRecorder, $whereConditions, $setLanguageFields);
             }
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1644,7 +1644,7 @@ class TCMSTableEditorEndPoint
         } else {
             $oLanguageCopyList = new TIterator();
         }
-        $setFields = array();
+        $dataForChangeRecorder = array();
         $setLanguageFields = array();
         $editablePostFields = [];
         /** @var $oField TCMSField */
@@ -1724,13 +1724,13 @@ class TCMSTableEditorEndPoint
                     }
 
                     $query .= '`'.MySqlLegacySupport::getInstance()->real_escape_string($sqlFieldNameWithLanguagCode)."` = '".MySqlLegacySupport::getInstance()->real_escape_string($sqlValue)."'";
-                    $setFields[$oField->name] = $sqlValue;
+                    $dataForChangeRecorder[$oField->name] = $sqlValue;
                 }
             }
         }
 
         if(null !== $this->sId) {
-            $setFields = $this->filterUnchangedFields(
+            $dataForChangeRecorder = $this->filterUnchangedFields(
                 $editablePostFields,
                 $tableName,
                 $this->sId
@@ -1764,7 +1764,7 @@ class TCMSTableEditorEndPoint
             do {
                 $uid = TTools::GetUUID();
                 $sInsertQuery = $query.", `id`='".MySqlLegacySupport::getInstance()->real_escape_string($uid)."'";
-                $setFields['id'] = $uid;
+                $dataForChangeRecorder['id'] = $uid;
                 MySqlLegacySupport::getInstance()->query($sInsertQuery);
                 $error = MySqlLegacySupport::getInstance()->error();
                 if (!empty($error)) {
@@ -1794,8 +1794,8 @@ class TCMSTableEditorEndPoint
             $this->LoadDataFromDatabase();
             /** @var  $migrationRecorderStateHandler MigrationRecorderStateHandler */
             $migrationRecorderStateHandler = ServiceLocator::get('chameleon_system_database_migration.recorder.migration_recorder_state_handler');
-            if ($this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive() && count($setFields) >= 1) {
-                $this->writePostWriteLogChangeData($bIsUpdateCall, $setFields, $whereConditions, $setLanguageFields);
+            if ($this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive() && count($dataForChangeRecorder) >= 1) {
+                $this->writePostWriteLogChangeData($bIsUpdateCall, $dataForChangeRecorder, $whereConditions, $setLanguageFields);
             }
 
             TCacheManager::PerformeTableChange($tableName, $this->sId);

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1784,12 +1784,6 @@ class TCMSTableEditorEndPoint
         if ($databaseChanged) {
             $this->LoadDataFromDatabase();
             if (true === $bIsUpdateCall && true === $this->isRecordingActive() && \count($dataForChangeRecorder) > 0) {
-                $dataForChangeRecorder = $this->filterUnchangedFields(
-                    $dataForChangeRecorder,
-                    $tableName,
-                    $this->sId
-                );
-
                 if (\count($dataForChangeRecorder) > 0) {
                     $this->writePostWriteLogChangeData(
                         $bIsUpdateCall,
@@ -1836,30 +1830,6 @@ class TCMSTableEditorEndPoint
         $migrationRecorderStateHandler = $this->getMigrationRecorderStateHandler();
         
         return $this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive();
-    }
-
-    private function filterUnchangedFields(array $editableFields, string $tableName, string $id): array
-    {
-        // TODO / NOTE TCMSShopTableEditor_ShopArticle.class.php:PostSaveHook():108
-        //  calls this with different languages set for the table conf but the oTablePreChangeData
-        //  here remains unchanged. => Language mismatch during comparisson.
-        
-        $dataBeforeUpdate = $this->oTablePreChangeData->sqlData;
-
-        $filteredFields = [];
-
-        foreach ($editableFields as $fieldName => $value) {
-            $oldDataExists = \array_key_exists($fieldName, $dataBeforeUpdate);
-            
-            // TODO / NOTE \TCMSTableEditorChangeLog::computeDifferences() is much more complex than the
-            //  following !== - is this a problem?
-            
-            if (false === $oldDataExists || (true === $oldDataExists && $dataBeforeUpdate[$fieldName] !== $value)) {
-                $filteredFields[$fieldName] = $value;
-            }
-        }
-
-       return $filteredFields;
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1646,7 +1646,6 @@ class TCMSTableEditorEndPoint
         }
         $dataForChangeRecorder = array();
         $setLanguageFields = array();
-        $editablePostFields = [];
         /** @var $oField TCMSField */
         while ($oField = $oFields->Next()) {
             $sFieldDisplayType = 'none';
@@ -1694,7 +1693,7 @@ class TCMSTableEditorEndPoint
                     $aPropertyFields[] = $oField;
                 }
                 // now convert field name (if this is a multi-language field)
-                $sqlFieldNameWithLanguagCode = $oField->oDefinition->GetRealEditFieldName($languageId);
+                $sqlFieldNameWithLanguageCode = $oField->oDefinition->GetRealEditFieldName($languageId);
                 if (false !== $sqlValue && false !== $writeField) {
                     if ($isFirst) {
                         $isFirst = false;
@@ -1703,27 +1702,25 @@ class TCMSTableEditorEndPoint
                         $query .= ', ';
                     }
 
-                    $editablePostFields[$sqlFieldNameWithLanguagCode] = $sqlValue;
-
                     if ($bCopyAllLanguages && '1' == $oField->oDefinition->sqlData['is_translatable']) {
-                        $sqlFieldNameWithLanguagCode = $oField->oDefinition->sqlData['name'];
-                        $sqlValue = $oField->oTableRow->sqlData[$sqlFieldNameWithLanguagCode];
+                        $sqlFieldNameWithLanguageCode = $oField->oDefinition->sqlData['name'];
+                        $sqlValue = $oField->oTableRow->sqlData[$sqlFieldNameWithLanguageCode];
                         $oLanguageCopyList->GoToStart();
                         while ($oLanguageCopy = $oLanguageCopyList->Next()) {
                             $sTargetFieldNameLanguage = $oField->oDefinition->GetEditFieldNameForLanguage($oLanguageCopy);
-                            if ($sTargetFieldNameLanguage && $sTargetFieldNameLanguage !== $sqlFieldNameWithLanguagCode) {
+                            if ($sTargetFieldNameLanguage && $sTargetFieldNameLanguage !== $sqlFieldNameWithLanguageCode) {
                                 $sqlValueLanguage = $oField->oTableRow->sqlData[$sTargetFieldNameLanguage];
                                 $query .= ' `'.MySqlLegacySupport::getInstance()->real_escape_string($sTargetFieldNameLanguage)."` = '".MySqlLegacySupport::getInstance()->real_escape_string($sqlValueLanguage)."', ";
 
                                 if (false === isset($setLanguageFields[$oLanguageCopy->fieldIso6391])) {
                                     $setLanguageFields[$oLanguageCopy->fieldIso6391] = array();
                                 }
-                                $setLanguageFields[$oLanguageCopy->fieldIso6391][$sqlFieldNameWithLanguagCode] = $sqlValueLanguage;
+                                $setLanguageFields[$oLanguageCopy->fieldIso6391][$sqlFieldNameWithLanguageCode] = $sqlValueLanguage;
                             }
                         }
                     }
 
-                    $query .= '`'.MySqlLegacySupport::getInstance()->real_escape_string($sqlFieldNameWithLanguagCode)."` = '".MySqlLegacySupport::getInstance()->real_escape_string($sqlValue)."'";
+                    $query .= '`'.MySqlLegacySupport::getInstance()->real_escape_string($sqlFieldNameWithLanguageCode)."` = '".MySqlLegacySupport::getInstance()->real_escape_string($sqlValue)."'";
                     $dataForChangeRecorder[$oField->name] = $sqlValue;
                 }
             }
@@ -1746,7 +1743,6 @@ class TCMSTableEditorEndPoint
         $sourceRecordID = $this->sId;
 
         if (false === $bIsUpdateCall) {
-            // handle insert query
             $databaseChanged = false;
 
             // need to create an id.. try to insert until we have a free id. We will try at most 3 times
@@ -1773,7 +1769,7 @@ class TCMSTableEditorEndPoint
                 }
                 --$iMaxTry;
             } while ($iMaxTry > 0 && false === $databaseChanged);
-        } else { // handle update query
+        } else {
             if (MySqlLegacySupport::getInstance()->query($query)) {
                 $databaseChanged = true;
             } else {

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1730,7 +1730,7 @@ class TCMSTableEditorEndPoint
         }
 
         if(null !== $this->sId) {
-            $setFields = $this->filterUnchangedFieldsFromPostData(
+            $setFields = $this->filterUnchangedFields(
                 $editablePostFields,
                 $tableName,
                 $this->sId
@@ -1828,7 +1828,7 @@ class TCMSTableEditorEndPoint
         return $bSaveSuccess;
     }
 
-    private function filterUnchangedFieldsFromPostData(array $editableFields, string $tableName, string $id): array
+    private function filterUnchangedFields(array $editableFields, string $tableName, string $id): array
     {
         $escapedTableName = $this->databaseConnection->quoteIdentifier($tableName);
         $dataBeforeUpdateQuery = 'SELECT * FROM '.$escapedTableName.' WHERE `id` = :id';

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1781,12 +1781,9 @@ class TCMSTableEditorEndPoint
             }
         }
 
-        // we need this because we use a redirect later and would not see the error message, we need to change this later to a nice error_logging or something
         if ($bWasInserted) {
             $this->LoadDataFromDatabase();
-            /** @var  $migrationRecorderStateHandler MigrationRecorderStateHandler */
-            $migrationRecorderStateHandler = ServiceLocator::get('chameleon_system_database_migration.recorder.migration_recorder_state_handler');
-            if ($this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive() && count($dataForChangeRecorder) >= 1) {
+            if (true === $this->isRecordingActive() && \count($dataForChangeRecorder) > 0) {
                 if (null !== $this->sId) {
                     $dataForChangeRecorder = $this->filterUnchangedFields(
                         $editablePostFields,
@@ -1800,6 +1797,7 @@ class TCMSTableEditorEndPoint
 
             TCacheManager::PerformeTableChange($tableName, $this->sId);
         } else {
+            // we need this because we use a redirect later and would not see the error message
             TTools::WriteLogEntrySimple('SQL Error: '.$error, 1, __FILE__, __LINE__);
         }
 
@@ -1826,6 +1824,13 @@ class TCMSTableEditorEndPoint
         }
 
         return $bSaveSuccess;
+    }
+    
+    private function isRecordingActive(): bool
+    {
+        $migrationRecorderStateHandler = $this->getMigrationRecorderStateHandler();
+        
+        return $this->IsQueryLoggingAllowed() && $migrationRecorderStateHandler->isDatabaseLoggingActive();
     }
 
     private function filterUnchangedFields(array $editableFields, string $tableName, string $id): array
@@ -3147,5 +3152,10 @@ class TCMSTableEditorEndPoint
     private function getInputFilterUtil(): InputFilterUtilInterface
     {
         return ServiceLocator::get('chameleon_system_core.util.input_filter');
+    }
+    
+    private function getMigrationRecorderStateHandler(): MigrationRecorderStateHandler
+    {
+        return ServiceLocator::get('chameleon_system_database_migration.recorder.migration_recorder_state_handler');
     }
 }

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -1728,7 +1728,13 @@ class TCMSTableEditorEndPoint
             }
         }
 
-        $setFields = $this->filterUnchangedFieldsFromPostData($postFieldsLanguageConvertedWithAccessRights, $tableName, $this->sId);
+        if(null !== $this->sId) {
+            $setFields = $this->filterUnchangedFieldsFromPostData(
+                $postFieldsLanguageConvertedWithAccessRights,
+                $tableName,
+                $this->sId
+            );
+        }
 
         if ($isFirst) {
             return false;
@@ -1831,8 +1837,9 @@ class TCMSTableEditorEndPoint
         $dataBeforeUpdateQueryResult =  $stmt->fetchAll();
         $dataBeforeUpdate = $dataBeforeUpdateQueryResult[0];
         $filteredSetFields = [];
-        foreach ($postFieldsLanguageConvertedWithAccessRights as $postKey => $postValue){
-            if (array_key_exists($postKey, $dataBeforeUpdate) && $dataBeforeUpdate[$postKey] !== $postValue) {
+        foreach ($postFieldsLanguageConvertedWithAccessRights as $postKey => $postValue) {
+            $arrayKeyExists = array_key_exists($postKey, $dataBeforeUpdate);
+            if (false === $arrayKeyExists || (true === $arrayKeyExists && $dataBeforeUpdate[$postKey] !== $postValue)) {
                 $filteredSetFields[$postKey] = $postValue;
             }
         }


### PR DESCRIPTION
… been changed

| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes    
| Fixed issues  | chameleon-system/chameleon-system#591 
| License       | MIT

Until now, all fields, including those that have not been changed, were always written to the update script. Now there is a new method called filterUnchangedFieldsFromPostData() that filters unchanged fields from the data used for the log file

