### PR TITLE
ref #620: NavigationTreeSingleSelectWysiwyg: remove useless services

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelect/NavigationTreeSingleSelect.php
@@ -17,9 +17,7 @@ use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
 use ChameleonSystem\CoreBundle\Util\FieldTranslationUtil;
 use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
 use ChameleonSystem\CoreBundle\Util\UrlUtil;
-use Doctrine\DBAL\Connection;
 use MTPkgViewRendererAbstractModuleMapper;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use TGlobal;
 use TTools;
@@ -117,7 +115,6 @@ class NavigationTreeSingleSelect extends MTPkgViewRendererAbstractModuleMapper
         $this->tools = $tools;
         $this->global = $global;
         $this->fieldTranslationUtil = $fieldTranslationUtil;
-
         $this->editLanguage = $languageService->getActiveEditLanguage();
     }
 

--- a/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
+++ b/src/CoreBundle/Bridge/Chameleon/Module/NavigationTreeSingleSelectWysiwyg/NavigationTreeSingleSelectWysiwyg.php
@@ -18,8 +18,6 @@ use ChameleonSystem\CoreBundle\Service\LanguageServiceInterface;
 use ChameleonSystem\CoreBundle\Util\FieldTranslationUtil;
 use ChameleonSystem\CoreBundle\Util\InputFilterUtilInterface;
 use ChameleonSystem\CoreBundle\Util\UrlUtil;
-use Doctrine\DBAL\Connection;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\TranslatorInterface;
 use TGlobal;
@@ -36,8 +34,6 @@ class NavigationTreeSingleSelectWysiwyg extends NavigationTreeSingleSelect
     private $requestStack;
 
     public function __construct(
-        Connection $dbConnection,
-        EventDispatcherInterface $eventDispatcher,
         InputFilterUtilInterface $inputFilterUtil,
         UrlUtil $urlUtil,
         BackendTreeNodeFactory $backendTreeNodeFactory,
@@ -49,8 +45,6 @@ class NavigationTreeSingleSelectWysiwyg extends NavigationTreeSingleSelect
         RequestStack $requestStack
     ) {
         parent::__construct(
-            $dbConnection,
-            $eventDispatcher,
             $inputFilterUtil,
             $urlUtil,
             $backendTreeNodeFactory,

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -950,8 +950,6 @@
 
         <service id="chameleon_system_core.module.navigation_tree_single_select_wysiwyg" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelectWysiwyg\NavigationTreeSingleSelectWysiwyg" shared="false">
             <tag name="chameleon_system.module"/>
-            <argument id="database_connection" type="service"/>
-            <argument id="event_dispatcher" type="service"/>
             <argument id="chameleon_system_core.util.input_filter" type="service"/>
             <argument id="chameleon_system_core.util.url" type="service"/>
             <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
@@ -961,7 +959,6 @@
             <argument type="service" id="chameleon_system_core.util.field_translation"/>
             <argument type="service" id="chameleon_system_core.language_service"/>
             <argument id="request_stack" type="service"/>
-            <argument id="chameleon_system_core.cache" type="service"/>
         </service>
 
     </services>

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -948,16 +948,8 @@
             <argument type="service" id="chameleon_system_core.language_service"/>
         </service>
 
-        <service id="chameleon_system_core.module.navigation_tree_single_select_wysiwyg" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelectWysiwyg\NavigationTreeSingleSelectWysiwyg" shared="false">
+        <service id="chameleon_system_core.module.navigation_tree_single_select_wysiwyg" class="ChameleonSystem\CoreBundle\Bridge\Chameleon\Module\NavigationTreeSingleSelectWysiwyg\NavigationTreeSingleSelectWysiwyg" parent="chameleon_system_core.module.navigation_tree_single_select" shared="false">
             <tag name="chameleon_system.module"/>
-            <argument id="chameleon_system_core.util.input_filter" type="service"/>
-            <argument id="chameleon_system_core.util.url" type="service"/>
-            <argument id="chameleon_system_core.factory.backend_tree_node" type="service"/>
-            <argument id="chameleon_system_core.translator" type="service"/>
-            <argument id="chameleon_system_core.tools" type="service"/>
-            <argument id="chameleon_system_core.global" type="service"/>
-            <argument type="service" id="chameleon_system_core.util.field_translation"/>
-            <argument type="service" id="chameleon_system_core.language_service"/>
             <argument id="request_stack" type="service"/>
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | features / 6.3.x for bug fixes
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#620
| License       | MIT

After a Symfony and PHP update, it is no longer tolerated that a child class has different service parameters than its parent. This leads to an error now.
I have removed the unnecessary services in NavigationTreeSingleSelectWysiwyg

