### PR TITLE
add pre-output-event

### DIFF
--- a/src/CoreBundle/Controller/ChameleonController.php
+++ b/src/CoreBundle/Controller/ChameleonController.php
@@ -14,6 +14,7 @@ namespace ChameleonSystem\CoreBundle\Controller;
 use ChameleonSystem\CoreBundle\CoreEvents;
 use ChameleonSystem\CoreBundle\DataAccess\DataAccessCmsMasterPagedefInterface;
 use ChameleonSystem\CoreBundle\Event\HtmlIncludeEvent;
+use ChameleonSystem\CoreBundle\Event\PreOutputEvent;
 use ChameleonSystem\CoreBundle\Interfaces\ResourceCollectorInterface;
 use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
@@ -535,7 +536,13 @@ abstract class ChameleonController implements ChameleonControllerInterface
                 $bHeaderParsed = true;
             }
         }
+
+        $event = new PreOutputEvent($sPageContent, $this->getRequest());
+        $this->eventDispatcher->dispatch($event, CoreEvents::PRE_OUTPUT);
+        $sPageContent = $event->getContent();
+
         $sPageContent = $this->responseVariableReplacer->replaceVariables($sPageContent);
+
         $this->sGeneratedPage .= $sPageContent;
 
         return $sPageContent;

--- a/src/CoreBundle/CoreEvents.php
+++ b/src/CoreBundle/CoreEvents.php
@@ -64,4 +64,12 @@ final class CoreEvents
     const BEFORE_DELETE_MEDIA = 'chameleon_system_core.before_delete_media';
 
     const DISPLAY_LISTMANAGER_CELL = 'chameleon_system_core.display_listmanager_cell';
+
+    /**
+     * chameleon_system_core.pre_output is dispatched right before the content is sent to the client.
+     * It can be used to manipulate the content in a way where the
+     * \ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface is not sufficient.
+     * See \ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer for an example.
+     */
+    const PRE_OUTPUT = 'chameleon_system_core.pre_output';
 }

--- a/src/CoreBundle/Event/PreOutputEvent.php
+++ b/src/CoreBundle/Event/PreOutputEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ChameleonSystem\CoreBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class PreOutputEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $content;
+    /**
+     * @var Request
+     */
+    private $request;
+
+    public function __construct(string $content, Request $request)
+    {
+        $this->content = $content;
+        $this->request = $request;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $content
+     */
+    public function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+
+}


### PR DESCRIPTION
fixes #620

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes   
| Fixed issues  | chameleon-system/chameleon-system#620
| License       | MIT

This adds a new event: `chameleon_system_core.pre_output`
It is dispatched before content is sent to the client.
It can be used to manipulate the content in a more sophisticated way than just using the `ResponseVariableReplacerInterface`