### PR TITLE
add filter-response-event

### DIFF
--- a/src/CoreBundle/Controller/ChameleonController.php
+++ b/src/CoreBundle/Controller/ChameleonController.php
@@ -538,7 +538,7 @@ abstract class ChameleonController implements ChameleonControllerInterface
         }
 
         $event = new FilterContentEvent($sPageContent);
-        $this->eventDispatcher->dispatch($event, CoreEvents::FILTER_RESPONSE);
+        $this->eventDispatcher->dispatch($event, CoreEvents::FILTER_CONTENT);
         $sPageContent = $event->getContent();
         $this->sGeneratedPage .= $sPageContent;
 

--- a/src/CoreBundle/Controller/ChameleonController.php
+++ b/src/CoreBundle/Controller/ChameleonController.php
@@ -14,7 +14,7 @@ namespace ChameleonSystem\CoreBundle\Controller;
 use ChameleonSystem\CoreBundle\CoreEvents;
 use ChameleonSystem\CoreBundle\DataAccess\DataAccessCmsMasterPagedefInterface;
 use ChameleonSystem\CoreBundle\Event\HtmlIncludeEvent;
-use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
+use ChameleonSystem\CoreBundle\Event\FilterContentEvent;
 use ChameleonSystem\CoreBundle\Interfaces\ResourceCollectorInterface;
 use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
@@ -537,7 +537,7 @@ abstract class ChameleonController implements ChameleonControllerInterface
             }
         }
 
-        $event = new FilterResponseEvent($sPageContent);
+        $event = new FilterContentEvent($sPageContent);
         $this->eventDispatcher->dispatch($event, CoreEvents::FILTER_RESPONSE);
         $sPageContent = $event->getContent();
         $this->sGeneratedPage .= $sPageContent;

--- a/src/CoreBundle/Controller/ChameleonController.php
+++ b/src/CoreBundle/Controller/ChameleonController.php
@@ -14,6 +14,7 @@ namespace ChameleonSystem\CoreBundle\Controller;
 use ChameleonSystem\CoreBundle\CoreEvents;
 use ChameleonSystem\CoreBundle\DataAccess\DataAccessCmsMasterPagedefInterface;
 use ChameleonSystem\CoreBundle\Event\HtmlIncludeEvent;
+use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
 use ChameleonSystem\CoreBundle\Interfaces\ResourceCollectorInterface;
 use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
@@ -535,7 +536,10 @@ abstract class ChameleonController implements ChameleonControllerInterface
                 $bHeaderParsed = true;
             }
         }
-        $sPageContent = $this->responseVariableReplacer->replaceVariables($sPageContent);
+
+        $event = new FilterResponseEvent($sPageContent);
+        $this->eventDispatcher->dispatch($event, CoreEvents::FILTER_RESPONSE);
+        $sPageContent = $event->getContent();
         $this->sGeneratedPage .= $sPageContent;
 
         return $sPageContent;

--- a/src/CoreBundle/CoreEvents.php
+++ b/src/CoreBundle/CoreEvents.php
@@ -64,4 +64,12 @@ final class CoreEvents
     const BEFORE_DELETE_MEDIA = 'chameleon_system_core.before_delete_media';
 
     const DISPLAY_LISTMANAGER_CELL = 'chameleon_system_core.display_listmanager_cell';
+
+    /**
+     * chameleon_system_core.filter_response is dispatched right before the content is sent to the client.
+     * It has to be used instead of symfony's kernel.response when the content is flushed to the client
+     * before it reaches the end of execution. This is the case in layouts which use
+     * \ChameleonSystem\CoreBundle\Controller\ChameleonControllerInterface::FlushContentToBrowser
+     */
+    const FILTER_RESPONSE = 'chameleon_system_core.filter_response';
 }

--- a/src/CoreBundle/CoreEvents.php
+++ b/src/CoreBundle/CoreEvents.php
@@ -66,10 +66,10 @@ final class CoreEvents
     const DISPLAY_LISTMANAGER_CELL = 'chameleon_system_core.display_listmanager_cell';
 
     /**
-     * chameleon_system_core.filter_response is dispatched right before the content is sent to the client.
+     * chameleon_system_core.filter_content is dispatched right before the content is sent to the client.
      * It has to be used instead of symfony's kernel.response when the content is flushed to the client
      * before it reaches the end of execution. This is the case in layouts which use
      * \ChameleonSystem\CoreBundle\Controller\ChameleonControllerInterface::FlushContentToBrowser
      */
-    const FILTER_RESPONSE = 'chameleon_system_core.filter_response';
+    const FILTER_RESPONSE = 'chameleon_system_core.filter_content';
 }

--- a/src/CoreBundle/CoreEvents.php
+++ b/src/CoreBundle/CoreEvents.php
@@ -71,5 +71,5 @@ final class CoreEvents
      * before it reaches the end of execution. This is the case in layouts which use
      * \ChameleonSystem\CoreBundle\Controller\ChameleonControllerInterface::FlushContentToBrowser
      */
-    const FILTER_RESPONSE = 'chameleon_system_core.filter_content';
+    const FILTER_CONTENT = 'chameleon_system_core.filter_content';
 }

--- a/src/CoreBundle/Event/FilterContentEvent.php
+++ b/src/CoreBundle/Event/FilterContentEvent.php
@@ -13,7 +13,7 @@ namespace ChameleonSystem\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-final class FilterResponseEvent extends Event
+final class FilterContentEvent extends Event
 {
     /**
      * @var string

--- a/src/CoreBundle/Event/FilterResponseEvent.php
+++ b/src/CoreBundle/Event/FilterResponseEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ChameleonSystem\CoreBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class FilterResponseEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $content;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+
+}

--- a/src/CoreBundle/Event/FilterResponseEvent.php
+++ b/src/CoreBundle/Event/FilterResponseEvent.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace ChameleonSystem\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -840,7 +840,7 @@
         <service id="chameleon_system_core.response.response_variable_replacer" class="ChameleonSystem\CoreBundle\Response\ResponseVariableReplacer" public="true">
             <argument type="service" id="chameleon_system_core.security.authenticity_token.authenticity_token_manager"/>
             <argument type="service" id="chameleon_system_core.flash_messages"/>
-            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="handleResponse" priority="253"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.filter_content" method="handleResponse" priority="253"/>
         </service>
 
         <service id="cmsPkgCore.tableEditorListFieldState" class="TTableEditorListFieldState" public="true" />

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -840,6 +840,7 @@
         <service id="chameleon_system_core.response.response_variable_replacer" class="ChameleonSystem\CoreBundle\Response\ResponseVariableReplacer" public="true">
             <argument type="service" id="chameleon_system_core.security.authenticity_token.authenticity_token_manager"/>
             <argument type="service" id="chameleon_system_core.flash_messages"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="handleResponse" priority="253"/>
         </service>
 
         <service id="cmsPkgCore.tableEditorListFieldState" class="TTableEditorListFieldState" public="true" />

--- a/src/CoreBundle/Response/ResponseVariableReplacer.php
+++ b/src/CoreBundle/Response/ResponseVariableReplacer.php
@@ -11,7 +11,7 @@
 
 namespace ChameleonSystem\CoreBundle\Response;
 
-use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
+use ChameleonSystem\CoreBundle\Event\FilterContentEvent;
 use ChameleonSystem\CoreBundle\Interfaces\FlashMessageServiceInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\TokenInjectionFailedException;
@@ -45,7 +45,7 @@ class ResponseVariableReplacer implements ResponseVariableReplacerInterface
         $this->variables[$key] = $value;
     }
 
-    public function handleResponse(FilterResponseEvent $event)
+    public function handleResponse(FilterContentEvent $event)
     {
         $event->setContent($this->replaceVariables($event->getContent()));
     }

--- a/src/CoreBundle/Response/ResponseVariableReplacer.php
+++ b/src/CoreBundle/Response/ResponseVariableReplacer.php
@@ -11,6 +11,7 @@
 
 namespace ChameleonSystem\CoreBundle\Response;
 
+use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
 use ChameleonSystem\CoreBundle\Interfaces\FlashMessageServiceInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\AuthenticityTokenManagerInterface;
 use ChameleonSystem\CoreBundle\Security\AuthenticityToken\TokenInjectionFailedException;
@@ -42,6 +43,11 @@ class ResponseVariableReplacer implements ResponseVariableReplacerInterface
     public function addVariable(string $key, string $value): void
     {
         $this->variables[$key] = $value;
+    }
+
+    public function handleResponse(FilterResponseEvent $event)
+    {
+        $event->setContent($this->replaceVariables($event->getContent()));
     }
 
     /**


### PR DESCRIPTION
fixes #629

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes   
| Fixed issues  | chameleon-system/chameleon-system#629
| License       | MIT

This adds a new event: `chameleon_system_core.filter_response`
It is dispatched before content is sent to the client.
It can be used to manipulate the content in a more sophisticated way than just using the `ResponseVariableReplacerInterface`