### PR TITLE
mkdir error details with a exception

### DIFF
--- a/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
+++ b/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
@@ -112,7 +112,11 @@ class TPkgCmsFileManager_FileSystem implements IPkgCmsFileManager
             trigger_error('File permissions are handled by the administrator. Do not try to set the mode by hand.', E_USER_DEPRECATED);
         }
 
-        return mkdir($path, 0777, $recursive);
+        try {
+            return mkdir($path, 0777, $recursive);
+        } catch (Exception $e) {
+            throw new Exception(sprintf("Cannot creating folder %s. Error: %s", $path, $e->getMessage()));
+        }
     }
 
     /**

--- a/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
+++ b/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
@@ -115,7 +115,7 @@ class TPkgCmsFileManager_FileSystem implements IPkgCmsFileManager
         try {
             return mkdir($path, 0777, $recursive);
         } catch (Exception $e) {
-            throw new Exception(sprintf("Cannot create folder %s. Error: %s", $path, $e->getMessage()));
+            throw new Exception(sprintf("Cannot create folder %s. Error: %s", $path, $e->getMessage()), $e->getCode(), $e);
         }
     }
 

--- a/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
+++ b/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
@@ -115,7 +115,7 @@ class TPkgCmsFileManager_FileSystem implements IPkgCmsFileManager
         try {
             return mkdir($path, 0777, $recursive);
         } catch (Exception $e) {
-            throw new Exception(sprintf("Cannot creating folder %s. Error: %s", $path, $e->getMessage()));
+            throw new Exception(sprintf("Cannot create folder %s. Error: %s", $path, $e->getMessage()));
         }
     }
 

--- a/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
+++ b/src/CmsFileManagerBundle/objects/TPkgCmsFileManager_FileSystem.class.php
@@ -115,7 +115,7 @@ class TPkgCmsFileManager_FileSystem implements IPkgCmsFileManager
         try {
             return mkdir($path, 0777, $recursive);
         } catch (Exception $e) {
-            throw new Exception(sprintf("Cannot create folder %s. Error: %s", $path, $e->getMessage()), $e->getCode(), $e);
+            throw new Exception(sprintf("Cannot create folder %s.", $path), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes  
| Fixed issues  | chameleon-system/chameleon-system#632
| License       | MIT

When we try to create a new folder, we get only: " Warning: mkdir(): No such file or directory" as Error Message, but its without Path, Details and etc.

This Fix, pack the Folder Path and the Error,which mkdir() function returned, informations in an new Exception. And then we can see, which Path/Folder is wrong/missing in the Project.

