### PR TITLE
new password field updated with readonly

### DIFF
--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldPassword/passwordInput.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldPassword/passwordInput.html.twig
@@ -8,12 +8,12 @@
     </div>
     <div class="form-group row">
         <div class="col-xs-12 col-sm-10 col-md-8 col-lg-7">
-            <input type="password" autocomplete="off" id="{{ fieldName|e('html_attr') }}" name="{{ fieldName|e('html_attr') }}" class="strength form-control"{% if backendLanguageCode %} data-language="{{ backendLanguageCode|e('html_attr') }}"{% endif %} placeholder="{{ 'chameleon_system_core.field_password.new_password'|trans|e('html_attr') }}">
+            <input type="password" autocomplete="off" readonly="readonly" onfocus="this.removeAttribute('readonly');"  id="{{ fieldName|e('html_attr') }}" name="{{ fieldName|e('html_attr') }}" class="strength form-control"{% if backendLanguageCode %} data-language="{{ backendLanguageCode|e('html_attr') }}"{% endif %} placeholder="{{ 'chameleon_system_core.field_password.new_password'|trans|e('html_attr') }}">
         </div>
     </div>
     <div class="form-group row">
         <div class="col-xs-12 col-sm-10 col-md-8 col-lg-7">
-            <input type="password" autocomplete="off" id="{{ fieldName|e('html_attr') }}_check" name="{{ fieldName|e('html_attr') }}_check" class="strength form-control"{% if backendLanguageCode %} data-language="{{ backendLanguageCode|e('html_attr') }}"{% endif %} placeholder="{{ 'chameleon_system_core.field_password.repeat_password'|trans|e('html_attr') }}">
+            <input type="password" autocomplete="off" readonly="readonly" onfocus="this.removeAttribute('readonly');"  id="{{ fieldName|e('html_attr') }}_check" name="{{ fieldName|e('html_attr') }}_check" class="strength form-control"{% if backendLanguageCode %} data-language="{{ backendLanguageCode|e('html_attr') }}"{% endif %} placeholder="{{ 'chameleon_system_core.field_password.repeat_password'|trans|e('html_attr') }}">
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x, 7.0.x
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no 
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#633
| License       | MIT

The username and password input fields will be default as readonly set, then removing the readonly attribute directly via onfocus event.

That is a simplest and easiest solving for Password Manager Extensions.