### PR TITLE
ref #642: remove user's email from reset password link

### DIFF
--- a/src/ExtranetBundle/Bridge/Chameleon/Migration/Script/update-1601044140.inc.php
+++ b/src/ExtranetBundle/Bridge/Chameleon/Migration/Script/update-1601044140.inc.php
@@ -1,0 +1,13 @@
+<h1>Build #1601044140</h1>
+<h2>Date: 2020-09-25</h2>
+<div class="changelog">
+    - Info about "Forgot Password" email.
+</div>
+<?php
+TCMSLogChange::addInfoMessage(
+    'The "Forgot Password" email was changed to not include the user\'s email address 
+anymore. If \TdbDataExtranet::GetPasswordChangeURL() is overwritten in custom code, consider removing the email from the 
+URL. Also, any custom code that relies on the email being present in the URL, needs to be changed. This would most likely 
+be MTExtranet::ChangeForgotPassword() in case it is overwritten/extended.',
+    TCMSLogChange::INFO_MESSAGE_LEVEL_INFO
+);

--- a/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
+++ b/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
@@ -1032,20 +1032,13 @@ class MTExtranetCoreEndPoint extends TUserCustomModelBase
                         $this->data['bPasswordChanged'] = true;
                     }
                 }
+            } elseif (null !== $oUser && false === $oUser->IsPasswordChangeKeyValid()) {
+                $oMessage->AddMessage(TdbDataExtranetUser::MSG_FORM_FIELD, 'EXTRANET-FORGOT-PASSWORD-CHANGE-KEY-INVALID');
             } else {
                 $oMessage->AddMessage(TdbDataExtranetUser::MSG_FORM_FIELD, 'EXTRANET-FORGOT-PASSWORD-WRONG-USER-NAME');
             }
         } else { // show password change form
-            $oUser = $oUser->GetValidatedLoginUser($inputFilterUtil->getFilteredGetInput(TDataExtranetCore::URL_PARAMETER_LOGINNAME));
-            if (null !== $oUser && $passwordHashGenerator->verify($sToken, $oUser->fieldPasswordChangeKey)) {
-                $bPasswordChangeKeyValid = $oUser->IsPasswordChangeKeyValid();
-                if (!$bPasswordChangeKeyValid) {
-                    $oMessage->AddMessage(TdbDataExtranetUser::MSG_FORM_FIELD, 'EXTRANET-FORGOT-PASSWORD-CHANGE-KEY-INVALID');
-                }
-                $sUsername = $oUser->fieldName;
-            } else {
-                $oMessage->AddMessage(TdbDataExtranetUser::MSG_FORM_FIELD, 'EXTRANET-FORGOT-PASSWORD-USER-NOT-FOUND');
-            }
+            $oUser = null;
         }
 
         $this->data['sUsername'] = $sUsername;

--- a/src/ExtranetBundle/objects/db/TDataExtranetCore.class.php
+++ b/src/ExtranetBundle/objects/db/TDataExtranetCore.class.php
@@ -22,6 +22,9 @@ class TDataExtranetCore extends TDataExtranetCoreAutoParent
      */
     protected $bInternalCacheMarkedAsDirty = true;
 
+    /**
+     * @deprecated - This was only used by the forgot password email which does not include login name anymore.
+     */
     const URL_PARAMETER_LOGINNAME = 'loginname';
     const URL_PARAMETER_CHANGE_PASSWORD = 'pwchangekey';
 
@@ -222,7 +225,6 @@ class TDataExtranetCore extends TDataExtranetCoreAutoParent
         $node->Load($this->sqlData['forgot_password_treenode_id']);
         $data = array(
             'module_fnc' => array($spotName => 'ChangeForgotPassword'),
-            self::URL_PARAMETER_LOGINNAME => $loginname,
             self::URL_PARAMETER_CHANGE_PASSWORD => $key,
         );
         $link = static::getTreeService()->getLinkToPageForTreeAbsolute($node, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#642
| License       | MIT

Removes the user's email from Forgot Password links. If there is no custom code depending on it, which is unlikely, nothing has to be changed. Because we cannot fetch the user when showing the form for the new password (we have no email address to select by), we don't show a message right away when the URL token is invalid. Instead, messages will only be shown after the form is sent.
There is a new deprecation for the TDataExtranetCore::URL_PARAMETER_LOGINNAME constant, as it was only used for the reset password URL and should not be used anymore. I don't know if it is allowed to add a deprecation for a fix release in this case and where the deprecation notice should go.

