### PR TITLE
643 newsletter unsubscribe link email parameter

### DIFF
--- a/src/NewsletterBundle/Bridge/Chameleon/Migration/Script/update-1601284542.inc.php
+++ b/src/NewsletterBundle/Bridge/Chameleon/Migration/Script/update-1601284542.inc.php
@@ -1,0 +1,27 @@
+<h1>pkgnewsletter - Build #1601284542</h1>
+<div class="changelog">
+    - add message for "newsletter is not found"
+</div>
+<?php
+
+TCMSLogChange::AddFrontEndMessage(
+    'ERROR-UNSUBSCRIBE-NEWSLETTER-USER-NOT-FOUND',
+    'This newsletter subscription could not be found in our mailing list.',
+    '4',
+    'Given newsletter user ID or email address was not found when trying to unsubscribe.',
+    '',
+    'Core',
+    'standard',
+    'en'
+);
+
+TCMSLogChange::AddFrontEndMessage(
+    'ERROR-UNSUBSCRIBE-NEWSLETTER-USER-NOT-FOUND',
+    'Diese Newsletter-Anmeldung wurde in unserem Verteiler nicht gefunden.',
+    '4',
+    'Vom Newsletter abmelden: Die gegebene Newsletter-User ID oder E-Mail-Adresse wurde nicht gefunden.',
+    '',
+    'Core',
+    'standard',
+    'de'
+);

--- a/src/NewsletterBundle/objects/WebModules/MTPkgNewsletterSignoutCore/MTPkgNewsletterSignoutCore.class.php
+++ b/src/NewsletterBundle/objects/WebModules/MTPkgNewsletterSignoutCore/MTPkgNewsletterSignoutCore.class.php
@@ -89,7 +89,7 @@ class MTPkgNewsletterSignoutCore extends TUserCustomModelBase
             $aUserData = [];
         }
         $newsletterUserId = null;
-        if (array_key_exists(self::URL_PARAM_NEWSLETTER_USER_ID, $aUserData)) {
+        if (true === array_key_exists(self::URL_PARAM_NEWSLETTER_USER_ID, $aUserData)) {
             $newsletterUserId = $aUserData[self::URL_PARAM_NEWSLETTER_USER_ID];
         }
         if (array_key_exists(self::URL_PARAM_MAIL, $aUserData)) {

--- a/src/NewsletterBundle/objects/db/TPkgNewsletterUser.class.php
+++ b/src/NewsletterBundle/objects/db/TPkgNewsletterUser.class.php
@@ -275,7 +275,7 @@ class TPkgNewsletterUser extends TPkgNewsletterUserAutoParent
         if (false === $sUnsubscribeCode) {
             $aParams = array(
                 MTPkgNewsletterSignoutCore::URL_PARAM_DATA => array(
-                    self::URL_USER_ID_PARAMETER => $this->id,
+                    MTPkgNewsletterSignoutCore::URL_PARAM_NEWSLETTER_USER_ID => $this->id,
                     MTPkgNewsletterSignoutCore::URL_PARAM_GROUP_ID => $sPkgNewsletterGroupId,
                 ),
             );

--- a/src/NewsletterBundle/objects/db/TPkgNewsletterUser.class.php
+++ b/src/NewsletterBundle/objects/db/TPkgNewsletterUser.class.php
@@ -275,7 +275,7 @@ class TPkgNewsletterUser extends TPkgNewsletterUserAutoParent
         if (false === $sUnsubscribeCode) {
             $aParams = array(
                 MTPkgNewsletterSignoutCore::URL_PARAM_DATA => array(
-                    MTPkgNewsletterSignoutCore::URL_PARAM_MAIL => $this->fieldEmail,
+                    self::URL_USER_ID_PARAMETER => $this->id,
                     MTPkgNewsletterSignoutCore::URL_PARAM_GROUP_ID => $sPkgNewsletterGroupId,
                 ),
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#643
| License       | MIT

Instead of using the email address to get newsletter subscription from unsubscribe link, we use the ID of the subscription (= newsletter_user) now. This will only affect cases here CHAMELEON_PKG_NEWSLETTER_NEW_MODULE is false. Older links with the e-mail address will continue to work.
