### PR TITLE
Do not fetch length from post data if a value for $postData is given

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
@@ -745,10 +745,11 @@ class TCMSField implements TCMSFieldVisitableInterface
         $connection = $this->getDatabaseConnection();
         $inputFilterUtil = $this->getInputFilterUtil();
 
-        $lengthSet = $inputFilterUtil->getFilteredInput('length_set');
+        $lengthSet = '';
+        $cmsFieldTypeId = '';
+        $fieldDefaultValue = '';
 
         if (null !== $postData) {
-            $fieldDefaultValue = '';
             if (isset($postData['field_default_value'])) {
                 $fieldDefaultValue = $postData['field_default_value'];
             }
@@ -759,6 +760,7 @@ class TCMSField implements TCMSFieldVisitableInterface
         } else {
             $fieldDefaultValue = $inputFilterUtil->getFilteredInput('field_default_value');
             $cmsFieldTypeId = $inputFilterUtil->getFilteredInput('cms_field_type_id');
+            $lengthSet = $inputFilterUtil->getFilteredInput('length_set');
         }
 
         $fieldType = null;

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSField.class.php
@@ -736,11 +736,11 @@ class TCMSField implements TCMSFieldVisitableInterface
      * generate the field definition part of the sql statement
      * we assume that $oFieldDefinition holds the correct default value.
      *
-     * @param array $postData
+     * @param array $fieldDefinition
      *
      * @return string
      */
-    public function _GetSQLDefinition(&$postData = null)
+    public function _GetSQLDefinition(&$fieldDefinition = null)
     {
         $connection = $this->getDatabaseConnection();
         $inputFilterUtil = $this->getInputFilterUtil();
@@ -749,13 +749,13 @@ class TCMSField implements TCMSFieldVisitableInterface
         $cmsFieldTypeId = '';
         $fieldDefaultValue = '';
 
-        if (null !== $postData) {
-            if (isset($postData['field_default_value'])) {
-                $fieldDefaultValue = $postData['field_default_value'];
+        if (null !== $fieldDefinition) {
+            if (isset($fieldDefinition['field_default_value'])) {
+                $fieldDefaultValue = $fieldDefinition['field_default_value'];
             }
-            $cmsFieldTypeId = $postData['cms_field_type_id'];
-            if (!empty($postData['length_set'])) {
-                $lengthSet = $postData['length_set'];
+            $cmsFieldTypeId = $fieldDefinition['cms_field_type_id'];
+            if (!empty($fieldDefinition['length_set'])) {
+                $lengthSet = $fieldDefinition['length_set'];
             }
         } else {
             $fieldDefaultValue = $inputFilterUtil->getFilteredInput('field_default_value');

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldBoolean.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldBoolean.class.php
@@ -135,14 +135,14 @@ class TCMSFieldBoolean extends TCMSFieldOption
     /**
      * {@inheritdoc}
      */
-    public function _GetSQLDefinition(&$postData = null)
+    public function _GetSQLDefinition(&$fieldDefinition = null)
     {
         // never allow an empty default value for boolean fields
-        if (isset($postData['field_default_value']) && '' === $postData['field_default_value']) {
-            $postData['field_default_value'] = '0';
+        if (isset($fieldDefinition['field_default_value']) && '' === $fieldDefinition['field_default_value']) {
+            $fieldDefinition['field_default_value'] = '0';
         }
 
-        return parent::_GetSQLDefinition($postData);
+        return parent::_GetSQLDefinition($fieldDefinition);
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPortalLanguageMatrix.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPortalLanguageMatrix.class.php
@@ -386,11 +386,11 @@ class TCMSFieldPortalLanguageMatrix extends TCMSField
      * generate the field definition part of the sql statement
      * we assume that $oFieldDefinition holds the correct default value.
      *
-     * @param array $postData
+     * @param array $fieldDefinition
      *
      * @return string
      */
-    public function _GetSQLDefinition(&$postData = null)
+    public function _GetSQLDefinition(&$fieldDefinition = null)
     {
         return '';
     }


### PR DESCRIPTION
fixes #586

| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#586
| License       | MIT

When constructing the SQL for the new field, the core should either value the given data OR fetch the information from the post data. By doing both it was possible to break the SQL when mixing the type from the given data and the length from the post data, ignoring the fact that an empty length value in the field conf data might be a valid value.