### PR TITLE
Fix snippet renderer test setup

### DIFF
--- a/src/SnippetRendererBundle/Tests/Renderer/SnippetRendererTest.php
+++ b/src/SnippetRendererBundle/Tests/Renderer/SnippetRendererTest.php
@@ -29,7 +29,8 @@ class SnippetRendererTest extends TestCase
     public function setUp()
     {
         //$twigEnv = $this->getMockBuilder('Twig_Environment')->getMock();
-        $snippetRenderer = new TPkgSnippetRenderer(new Twig_Environment(new TwigStringLoader()));
+        $environment = new Twig_Environment(new TwigStringLoader());
+        $snippetRenderer = new TPkgSnippetRenderer($environment, $environment, new \Psr\Log\NullLogger());
         $container = new \Symfony\Component\DependencyInjection\ContainerBuilder();
         $container->set('chameleon_system_snippet_renderer.snippet_renderer', $snippetRenderer);
         ServiceLocator::setContainer($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | ~6.3~ 7.0
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | n/a  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In another recent Pull Request I noticed that tests are failing in travis because the `setUp` method of a test was out of date.
This fixes the test setup so they start passing again.

