### PR TITLE
ref #657: Cleanup order list initialization in TCMSListManagerFullGroupTable

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSListManager/TCMSListManagerFullGroupTable.class.php
@@ -54,15 +54,10 @@ class TCMSListManagerFullGroupTable extends TCMSListManager
             $cachedTableObj = $this->getTableFromSessionCache($listCacheKey);
         }
 
-        $aOrderData = array();
-        if (null !== $cachedTableObj) {
-            $aOrderData = $cachedTableObj->orderList;
-        }
-
         // table is not in cache, load it
         if (null === $cachedTableObj) {
             $this->CreateTableObj(); // also calls PostCreateTableObjectHook();
-            $this->tableObj->orderList = $aOrderData;
+            $this->tableObj->orderList = array();
             $this->AddFields();
             $this->AddSortInformation();
             $this->AddTableGrouping();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | ~6.3~ 7.0
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | https://github.com/chameleon-system/chameleon-system/issues/657   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

While debugging I found this instance, where `$aOrderData` is initialized only if a certain condition applies
but never used when that condition applies - the only usage of it is it's default value.
