### PR TITLE
Fix/538 add space between icon and name of tcmsfieldcmsuser field

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldCMSUser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldCMSUser.class.php
@@ -67,7 +67,7 @@ class TCMSFieldCMSUser extends TCMSFieldExtendedLookup
             $name .= ' ['.$oUser->sqlData['company'].']';
         }
 
-        $returnVal = $this->_GetHiddenField()."<div>{$imageTag}".TGlobal::OutHTML($name).'<div class="cleardiv">&nbsp;</div></div>';
+        $returnVal = $this->_GetHiddenField()."<div>{$imageTag} ".TGlobal::OutHTML($name).'<div class="cleardiv">&nbsp;</div></div>';
 
         return $returnVal;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed issues  | chameleon-system/chameleon-system#538
| License       | MIT

Just added a space at the right place, so the field does not look all squished up
