### PR TITLE
ref #663: Correctly detect update calls for cache clearing

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorMedia.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorMedia.class.php
@@ -452,8 +452,9 @@ class TCMSTableEditorMedia extends TCMSTableEditorFiles
                     }
                 }
             }
+
             // if there was a change of the image, we need to clear related cache elements
-            if (is_object($this->oTablePreChangeData)) {
+            if ($this->bIsUpdateCall) {
                 $this->ClearCacheOfObjectsUsingImage($media->id);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | ~6.3.x~ 7.0
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#663   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

`TCMSTableEditorMedia` now uses `bIsUpdateCall` in order to check if the media is new or has existed before.