### PR TITLE
ref 609: add outline: none; to nav item, so that the weird looking ou…

### DIFF
--- a/src/CoreBundle/Resources/public/themes/standard/css/global.css
+++ b/src/CoreBundle/Resources/public/themes/standard/css/global.css
@@ -355,6 +355,7 @@ legend {
 
 .sidebar .nav-item:focus {
     background-color: #20a8d8;
+    outline: none;
 }
 
 .sidebar-filter-input, .sidebar-filter-input:focus {


### PR DESCRIPTION
…tline, that chrome adds by default if an element is focused, disapears

| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  |no 
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no 
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#609
| License       | MIT

