### PR TITLE
update version contraints to include newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ckeditor/ckeditor": "4.6.2",
         "coreui/coreui": "^2.1",
         "dmhendricks/file-icon-vectors": "~1.0",
-        "doctrine/dbal": "~2.9.0",
+        "doctrine/dbal": "~2.9",
         "doctrine/doctrine-bundle": "2.0.7",
         "ext-curl": "*",
         "ext-pdo": "*",
@@ -30,9 +30,9 @@
         "php": "^7.1",
         "phpmailer/phpmailer": "~6.0",
         "symfony/monolog-bundle": "3.5.0",
-        "symfony/polyfill-apcu": "1.13.1",
-        "symfony/symfony": "4.4.13",
-        "symfony-cmf/routing-bundle": "2.2.0",
+        "symfony/polyfill-apcu": "~1.13.1",
+        "symfony/symfony": "~4.4.13",
+        "symfony-cmf/routing-bundle": "~2.2.0",
         "tedivm/jshrink": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#670 / chameleon-system/chameleon-system#671
| License       | MIT

The version constraints have been loosened to allow patch level updates. For the dbal dependency the constraint has been set to how it was in previous chameleon versions so it includes minor versions.
