### PR TITLE
fix: make trusted proxy handling compatible with symfony 4

### DIFF
--- a/src/CoreBundle/ChameleonHttpKernel.php
+++ b/src/CoreBundle/ChameleonHttpKernel.php
@@ -21,22 +21,6 @@ class ChameleonHttpKernel extends HttpKernel
      * @var string
      */
     private $trustedProxies;
-    /**
-     * @var string
-     */
-    private $trustedHeaderClientIp;
-    /**
-     * @var string
-     */
-    private $trustedHeaderClientHost;
-    /**
-     * @var string
-     */
-    private $trustedHeaderClientPort;
-    /**
-     * @var string
-     */
-    private $trustedHeaderClientProtocol;
 
     /**
      * {@inheritdoc}
@@ -53,21 +37,8 @@ class ChameleonHttpKernel extends HttpKernel
                 }
             }
             if (count($aTrustedProxies) > 0) {
-                Request::setTrustedProxies($aTrustedProxies);
+                Request::setTrustedProxies($aTrustedProxies, Request::getTrustedHeaderSet());
             }
-        }
-
-        if ('' !== $this->trustedHeaderClientIp) {
-            Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, $this->trustedHeaderClientIp);
-        }
-        if ('' !== $this->trustedHeaderClientHost) {
-            Request::setTrustedHeaderName(Request::HEADER_CLIENT_HOST, $this->trustedHeaderClientHost);
-        }
-        if ('' !== $this->trustedHeaderClientPort) {
-            Request::setTrustedHeaderName(Request::HEADER_CLIENT_PORT, $this->trustedHeaderClientPort);
-        }
-        if ('' !== $this->trustedHeaderClientProtocol) {
-            Request::setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, $this->trustedHeaderClientProtocol);
         }
 
         return parent::handle($request, $type, $catch);
@@ -81,35 +52,4 @@ class ChameleonHttpKernel extends HttpKernel
         $this->trustedProxies = $trustedProxies;
     }
 
-    /**
-     * @param string $trustedHeaderClientIp
-     */
-    public function setTrustedHeaderClientIp($trustedHeaderClientIp)
-    {
-        $this->trustedHeaderClientIp = $trustedHeaderClientIp;
-    }
-
-    /**
-     * @param string $trustedHeaderClientHost
-     */
-    public function setTrustedHeaderClientHost($trustedHeaderClientHost)
-    {
-        $this->trustedHeaderClientHost = $trustedHeaderClientHost;
-    }
-
-    /**
-     * @param string $trustedHeaderClientPort
-     */
-    public function setTrustedHeaderClientPort($trustedHeaderClientPort)
-    {
-        $this->trustedHeaderClientPort = $trustedHeaderClientPort;
-    }
-
-    /**
-     * @param string $trustedHeaderClientProtocol
-     */
-    public function setTrustedHeaderClientProtocol($trustedHeaderClientProtocol)
-    {
-        $this->trustedHeaderClientProtocol = $trustedHeaderClientProtocol;
-    }
 }

--- a/src/CoreBundle/Resources/config/project-config.yml
+++ b/src/CoreBundle/Resources/config/project-config.yml
@@ -30,10 +30,6 @@ parameters:
   chameleon_system_core.mail_target_transformation_service.white_list: '@@PORTAL-DOMAINS'
 
   chameleon_system_core.request.trusted_proxies: "" # IP addresses (separated by comma) from which the forwarded headers are to be trusted. Make sure you define this when working in multi-server configurations
-  chameleon_system_core.request.trusted_header_client_ip: "" # the header under which the trusted proxy forwards the client IP address. defaults to X-Forwarded-For. See Symfony\Component\HttpFoundation\Request::setTrustedHeaderName for details
-  chameleon_system_core.request.trusted_header_client_host: "" # the header under which the trusted proxy forwards the client host. defaults to X-Forwarded-Host. See Symfony\Component\HttpFoundation\Request::setTrustedHeaderName for details
-  chameleon_system_core.request.trusted_header_client_port: "" # the header under which the trusted proxy forwards the client port. defaults to X-Forwarded-Port. See Symfony\Component\HttpFoundation\Request::setTrustedHeaderName for details
-  chameleon_system_core.request.trusted_header_client_protocol: "" # the header under which the trusted proxy forwards the client protocol. defaults to X-Forwarded-Proto. See Symfony\Component\HttpFoundation\Request::setTrustedHeaderName for details
 
   chameleon_system_core.resources.enable_external_resource_collection: true # if set to true, all external resources (css/js) are combined into one file
   chameleon_system_core.resources.enable_external_resource_collection_refresh_prefix: "v0" # if CSS & JS are combined into one file, you can use this prefix to force a reload for clients

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -66,18 +66,6 @@
             <call method="setTrustedProxies">
                 <argument>%chameleon_system_core.request.trusted_proxies%</argument>
             </call>
-            <call method="setTrustedHeaderClientIp">
-                <argument>%chameleon_system_core.request.trusted_header_client_ip%</argument>
-            </call>
-            <call method="setTrustedHeaderClientHost">
-                <argument>%chameleon_system_core.request.trusted_header_client_host%</argument>
-            </call>
-            <call method="setTrustedHeaderClientPort">
-                <argument>%chameleon_system_core.request.trusted_header_client_port%</argument>
-            </call>
-            <call method="setTrustedHeaderClientProtocol">
-                <argument>%chameleon_system_core.request.trusted_header_client_protocol%</argument>
-            </call>
         </service>
 
         <service id="chameleon_system_core.controller_resolver" class="ChameleonSystem\CoreBundle\Controller\ChameleonControllerResolver">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (see comment about custom header names
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#669
| License       | MIT

Custom header names aren't supported anymore in symfony so we will
remove them as well. If one really needs to handle this edge case it is
advisable to map to the default names in the entry point.

