### PR TITLE
87 - innerheight() with jquery height() replaced

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/table.js
+++ b/src/CoreBundle/Resources/public/javascript/table.js
@@ -112,8 +112,7 @@ $(document).ready(function () {
 
     // force links inside table cells to fixed height based on TR height
     $('.TCMSListManagerFullGroupTable tr.TGroupTableItemRow').each(function () {
-        var TRHeight = $(this).innerHeight() - 13; // - TD padding and borders
-        $(this).find('a.TGroupTableLink').css('height', TRHeight);
+        $(this).find('a.TGroupTableLink').css('height', $(this).height());
     });
 
     CHAMELEON.CORE.initializeEntryAutocomplete($('input#searchLookup'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x, 7.1x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#87
| License       | MIT

The offsetHeight does not include the height of pseudo-elements, because of that with jQuery.height() replaced.
