### PR TITLE
ref #681: Check registration result

### DIFF
--- a/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
+++ b/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
@@ -220,7 +220,11 @@ class MTExtranetCoreEndPoint extends TUserCustomModelBase
                 }
             }
 
-            if ($bDataValid && true === $oUser->Register()) {
+            if (true === $bDataValid) {
+                $bDataValid = $oUser->Register();
+            }
+
+            if (true === $bDataValid) {
                 $this->UpdateUserAddress(null, null, true);
                 // redirect to registration success page
                 if (!is_null($sSuccessURL)) {

--- a/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
+++ b/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
@@ -220,9 +220,7 @@ class MTExtranetCoreEndPoint extends TUserCustomModelBase
                 }
             }
 
-            if ($bDataValid) {
-                $oUser->Register();
-
+            if ($bDataValid && true === $oUser->Register()) {
                 $this->UpdateUserAddress(null, null, true);
                 // redirect to registration success page
                 if (!is_null($sSuccessURL)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#681   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Adds a check for the return value of `ExtranetUser::Register` to the 'success' criteria when registering a new user in order to prevent errors in the registration process from accidentally redirecting the user to the success URL while their new account was not created.