### PR TITLE
ref #695: New DataMailProfileTableEditor with migration

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1616755269.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1616755269.inc.php
@@ -1,0 +1,17 @@
+<h1>Build #1616755269</h1>
+<h2>Date: 2021-03-26</h2>
+<div class="changelog">
+    - 695: Validate Twig Syntax in Mail Templates
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_tbl_conf', 'de')
+  ->setFields([
+      'table_editor_class' => '\ChameleonSystem\CoreBundle\Bridge\Chameleon\TableEditor\DataMailProfileTableEditor',
+  ])
+  ->setWhereEquals([
+      'name' => 'data_mail_profile',
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);
+

--- a/src/CoreBundle/Bridge/Chameleon/TableEditor/DataMailProfileTableEditor.php
+++ b/src/CoreBundle/Bridge/Chameleon/TableEditor/DataMailProfileTableEditor.php
@@ -19,11 +19,10 @@ class DataMailProfileTableEditor extends TCMSTableEditor
         $twig = $this->getTwigEnvironment();
         try {
             $twig->tokenize(new Source($postData['body'], 'body'));
-            $twig->tokenize(new Source($postData['body_text'], 'body_text'));
         }catch (SyntaxError $e) {
 
             $this->getLogger()->error(
-                sprintf('failed to pares body field in E-Mail Template %s', $postData['name']),
+                sprintf('failed to parse body field in E-Mail Template %s', $postData['name']),
                 [
                     'sFieldName' => 'body',
                     'message' => $e->getMessage(),
@@ -35,9 +34,37 @@ class DataMailProfileTableEditor extends TCMSTableEditor
 
             $this->getFlashMessageService()->addMessage(
                 self::MESSAGE_MANAGER_CONSUMER,
-                'chameleon_system.table_editor_twig_error',
+                'chameleon_system.table_editor_twig_body_parse_error',
                 [
                     'sFieldName' => 'body',
+                    'message' => $e->getMessage(),
+                    'guess' => $e->guess(),
+                ]
+            );
+            return false;
+        }
+
+
+        try {
+            $twig->tokenize(new Source($postData['body_text'], 'body_text'));
+        }catch (SyntaxError $e) {
+
+            $this->getLogger()->error(
+                sprintf('failed to parse body_text field in E-Mail Template %s', $postData['name']),
+                [
+                    'sFieldName' => 'body_text',
+                    'message' => $e->getMessage(),
+                    'guess' => $e->guess(),
+                    'context' => $e->getSourceContext()->getCode(),
+                    'exception' => $e,
+                ]
+            );
+
+            $this->getFlashMessageService()->addMessage(
+                self::MESSAGE_MANAGER_CONSUMER,
+                'chameleon_system.table_editor_twig_body_text_parse_error',
+                [
+                    'sFieldName' => 'body_text',
                     'message' => $e->getMessage(),
                     'guess' => $e->guess(),
                 ]

--- a/src/CoreBundle/Bridge/Chameleon/TableEditor/DataMailProfileTableEditor.php
+++ b/src/CoreBundle/Bridge/Chameleon/TableEditor/DataMailProfileTableEditor.php
@@ -1,0 +1,65 @@
+<?php
+namespace ChameleonSystem\CoreBundle\Bridge\Chameleon\TableEditor;
+
+
+use ChameleonSystem\CoreBundle\Interfaces\FlashMessageServiceInterface;
+use ChameleonSystem\CoreBundle\ServiceLocator;
+use Psr\Log\LoggerInterface;
+use TCMSTableEditor;
+use Twig\Error\SyntaxError;
+use Twig\Environment;
+use Twig\Source;
+
+class DataMailProfileTableEditor extends TCMSTableEditor
+{
+    const MESSAGE_MANAGER_CONSUMER = 'DataMailProfileTableEditorMessages';
+
+    protected function DataIsValid(&$postData, $oFields = null)
+    {
+        $twig = $this->getTwigEnvironment();
+        try {
+            $twig->tokenize(new Source($postData['body'], 'body'));
+            $twig->tokenize(new Source($postData['body_text'], 'body_text'));
+        }catch (SyntaxError $e) {
+
+            $this->getLogger()->error(
+                sprintf('failed to pares body field in E-Mail Template %s', $postData['name']),
+                [
+                    'sFieldName' => 'body',
+                    'message' => $e->getMessage(),
+                    'guess' => $e->guess(),
+                    'context' => $e->getSourceContext()->getCode(),
+                    'exception' => $e,
+                ]
+            );
+
+            $this->getFlashMessageService()->addMessage(
+                self::MESSAGE_MANAGER_CONSUMER,
+                'chameleon_system.table_editor_twig_error',
+                [
+                    'sFieldName' => 'body',
+                    'message' => $e->getMessage(),
+                    'guess' => $e->guess(),
+                ]
+            );
+            return false;
+        }
+
+        return parent::DataIsValid($postData, $oFields);
+    }
+
+    private function getFlashMessageService(): FlashMessageServiceInterface
+    {
+        return ServiceLocator::get('chameleon_system_core.flash_messages');
+    }
+
+    private function getTwigEnvironment(): Environment
+    {
+        return ServiceLocator::get('twig');
+    }
+
+    private function getLogger(): LoggerInterface
+    {
+        return ServiceLocator::get('logger');
+    }
+}

--- a/src/CoreBundle/Resources/translations/messages.de.xliff
+++ b/src/CoreBundle/Resources/translations/messages.de.xliff
@@ -205,11 +205,11 @@
             </trans-unit>
             <trans-unit id="chameleon_system.table_editor_twig_body_parse_error">
                 <source>chameleon_system.table_editor_twig_body_parse_error</source>
-                <target>Fehler beim parsem das Feld Body in E-Mail Vorlage.</target>
+                <target>Fehler beim Parsen des Feldes 'Body' in E-Mail Vorlage.</target>
             </trans-unit>
             <trans-unit id="chameleon_system.table_editor_twig_body_text_parse_error">
                 <source>chameleon_system.table_editor_twig_body_text_parse_error</source>
-                <target>Fehler beim parsem das Feld Body in E-Mail Vorlage.</target>
+                <target>Fehler beim Parsen des Feldes 'Body Text' in E-Mail Vorlage.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/CoreBundle/Resources/translations/messages.de.xliff
+++ b/src/CoreBundle/Resources/translations/messages.de.xliff
@@ -203,7 +203,14 @@
                 <source>chameleon_system_core.template_tool.show_dynamic_box</source>
                 <target>anzeigen</target>
             </trans-unit>
-
+            <trans-unit id="chameleon_system.table_editor_twig_body_parse_error">
+                <source>chameleon_system.table_editor_twig_body_parse_error</source>
+                <target>Fehler beim parsem das Feld Body in E-Mail Vorlage.</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system.table_editor_twig_body_text_parse_error">
+                <source>chameleon_system.table_editor_twig_body_text_parse_error</source>
+                <target>Fehler beim parsem das Feld Body in E-Mail Vorlage.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/translations/messages.en.xliff
+++ b/src/CoreBundle/Resources/translations/messages.en.xliff
@@ -203,7 +203,14 @@
                 <source>chameleon_system_core.template_tool.show_dynamic_box</source>
                 <target>show</target>
             </trans-unit>
-
+            <trans-unit id="chameleon_system.table_editor_twig_body_parse_error">
+                <source>chameleon_system.table_editor_twig_body_parse_error</source>
+                <target>Failed to parse Body field in E-Mail Template.</target>
+            </trans-unit>
+            <trans-unit id="chameleon_system.table_editor_twig_body_text_parse_error">
+                <source>chameleon_system.table_editor_twig_body_text_parse_error</source>
+                <target>Failed to parse Body(Text) field in E-Mail Template.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/translations/messages.en.xliff
+++ b/src/CoreBundle/Resources/translations/messages.en.xliff
@@ -205,11 +205,11 @@
             </trans-unit>
             <trans-unit id="chameleon_system.table_editor_twig_body_parse_error">
                 <source>chameleon_system.table_editor_twig_body_parse_error</source>
-                <target>Failed to parse Body field in E-Mail Template.</target>
+                <target>Failed to parse 'Body' field in email Template.</target>
             </trans-unit>
             <trans-unit id="chameleon_system.table_editor_twig_body_text_parse_error">
                 <source>chameleon_system.table_editor_twig_body_text_parse_error</source>
-                <target>Failed to parse Body(Text) field in E-Mail Template.</target>
+                <target>Failed to parse 'Body Text' field in email Template.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      |  no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#695
| License       | MIT

The Twig Syntax Validation for DataMailProfile Table.

