### PR TITLE
ref #697: Update phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "~7.1.0",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~7.5"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#697   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The `TIteratorTest` used `assertIsArray` which was added in phpunit `7.5.0` (See https://github.com/sebastianbergmann/phpunit/blob/7.5.20/ChangeLog-7.5.md ). The dependency constraint however allowed installing everything from `7.0` - `7.5`. This change updates the dependency constraint to ensure that phpunit version 7.5.x is installed.

This should not have any effect on user facing logic since phpunit is only a dev dependency.