### PR TITLE
ref #699: Correct constructors after 652

### DIFF
--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSDocumentManagerTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSDocumentManagerTreeNode.class.php
@@ -20,7 +20,7 @@ class TCMSDocumentManagerTreeNode extends TCMSTreeNode
 
     public function __construct($id = null)
     {
-        parent::__construct('cms_document_tree', $id);
+        parent::__construct($id, 'cms_document_tree');
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSMediaManagerTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSMediaManagerTreeNode.class.php
@@ -20,7 +20,7 @@ class TCMSMediaManagerTreeNode extends TCMSTreeNode
 
     public function __construct($id = null)
     {
-        parent::__construct('cms_media_tree', $id);
+        parent::__construct($id, 'cms_media_tree');
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTemplateEngine/TCMSMasterPagedef.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTemplateEngine/TCMSMasterPagedef.class.php
@@ -57,7 +57,7 @@ class TCMSMasterPagedef extends TCMSMasterPagedefAutoParent
     public function __construct($id = null, $iLanguageId = null)
     {
         $this->table = 'cms_master_pagedef';
-        parent::__construct($this->table, $id, $iLanguageId);
+        parent::__construct($id, $iLanguageId);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#699
| License       | MIT

Test note: Additionally changes for documents and media items.