### PR TITLE
ref #681: Add correct return type annotation to TDataExtranetUser::Register

### DIFF
--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordWritable.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordWritable.class.php
@@ -100,7 +100,7 @@ class TCMSRecordWritable extends TCMSRecord
     /**
      * Save active data... create new record if no id present.
      *
-     * @return string|bool - id on success... else false
+     * @return string|false - id on success... else false
      */
     public function Save()
     {

--- a/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
+++ b/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
@@ -221,7 +221,7 @@ class MTExtranetCoreEndPoint extends TUserCustomModelBase
             }
 
             if (true === $bDataValid) {
-                $bDataValid = $oUser->Register();
+                $bDataValid = false !== $oUser->Register();
             }
 
             if (true === $bDataValid) {

--- a/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
+++ b/src/ExtranetBundle/objects/db/TDataExtranetUser.class.php
@@ -225,12 +225,13 @@ class TDataExtranetUser extends TDataExtranetUserAutoParent
      * @param bool $bForceUserConfirmMail
      * @param bool $bAutoLoginAfterRegistration
      *
-     * @return bool
+     * @return string|false - id on success, `false` if failed
      */
     public function Register($bForceUserConfirmMail = false, $bAutoLoginAfterRegistration = true)
     {
         $bRegistered = $this->Save($bForceUserConfirmMail);
-        if ($bRegistered) {
+
+        if (false !== $bRegistered) {
             if ($bAutoLoginAfterRegistration) {
                 $this->DirectLogin($this->fieldName, $this->fieldPassword);
                 $this->GetShippingAddress(true, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#681   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

See also: #539 - that's where this issue was introduced.

Before this, TDataExtranetUser::Register was annotated as `@return bool`
but returned the results of `TDataExtranetUser::Save`, which returns the
id or `false`.

This commit changes the return types to `string|false` and fixes it's
incorrect usage while registering a user.