### PR TITLE
ref #539: Convert input data to SQL format when registering a user

### DIFF
--- a/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
+++ b/src/ExtranetBundle/objects/WebModules/MTExtranetCore/MTExtranetCoreEndPoint.class.php
@@ -201,7 +201,7 @@ class MTExtranetCoreEndPoint extends TUserCustomModelBase
             $this->PrepareSubmittedData($aData);
             $extranetUserProvider->reset();
             $oUser = $extranetUserProvider->getActiveUser();
-            $oUser->LoadFromRow($aData);
+            $oUser->LoadFromRow($aData, true);
 
             $bDataValid = $this->ValidateUserLoginData();
             $bDataValid = $this->ValidateUserData() && $bDataValid;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch        | 7.0.x <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#539   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

During testing it emerged, that a users birthdate is not saved
correctly, as it is sent to the database in the format `DD.MM.YYYY`
instead of `YYYY-MM-DD`. Supplying the second argument to `LoadFromRow`
enables conversion of data formats, including dates.

