### PR TITLE
fix portal id table field name

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -950,7 +950,7 @@ class TCMSLogChange
         $existsCheckArray = [ 'name' => $sIdentifierName, ];
 
         if ('' !== $sPortalID) {
-            $existsCheckQuery .= ' AND `portal_id` = :portalId';
+            $existsCheckQuery .= ' AND `cms_portal_id` = :portalId';
             $existsCheckArray['portalId'] = $sPortalID;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/chameleon-system/chameleon-system/issues/809
| License       | MIT

Specifying a `PORTAL_ID` within the configuration array for method `TCMSLogChange::AddFrontEndMessage` like this:
```
\TCMSLogChange::AddFrontEndMessage(
    '<ID>',
    '<MESSAGE>',
    '<TYPE>',
    '<NOTE>',
    '<PORTAL_ID>', <---- anything but empty
    '<LOCATION>',
    '<VIEW>'
);
```
will adjust the insert query and uses the wrong table field name, what will make the query fail.
