### PR TITLE
match cms_tpl_page only on non-empty pagePath

### DIFF
--- a/src/CoreBundle/Resources/config/route_final.yml
+++ b/src/CoreBundle/Resources/config/route_final.yml
@@ -8,4 +8,4 @@ cms_tpl_page:
   path: /{pagePath}
   defaults: { _controller: chameleon_system_core.tpl_page_controller:getPage }
   requirements:
-    pagePath: ".*"
+    pagePath: ".+"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#713   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

See issue #713 for a detailed explanation of the fix.

