### PR TITLE
 ref #715: Add environment variable for symfony exception handler in CLI 

### DIFF
--- a/src/CoreBundle/bin/console
+++ b/src/CoreBundle/bin/console
@@ -32,6 +32,14 @@ require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
+/**
+ * #715: Use symfony error handling, when `USE_SYMFONY_CLI_ERROR_HANDLER=1` is set but default to
+ *       old-style error handler.
+ * @deprecated This flag exists to ease the move to symfony error handling.
+ *             It will be removed in the future and symfony error handling will become standard with 7.2
+ */
+$useSymfonyCliErrorHandler = '1' === getenv('USE_SYMFONY_CLI_ERROR_HANDLER');
+
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('--no-debug', '')) && 'prod' !== $env;
@@ -39,7 +47,9 @@ $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('-
 try {
     $kernel = new AppKernel($env, $debug);
     $application = new Application($kernel);
-    $application->setCatchExceptions(false);
+    if (false === $useSymfonyCliErrorHandler) {
+        $application->setCatchExceptions(false);
+    }
     $application->run($input);
 } catch (Exception $e) {
     echo $e;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#715   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Before this change, symfony exception handling was disabled in the CLI in favour of a simple `echo` call.
This enables symfony exception handling for CLI commands, if the `USE_SYMFONY_CLI_ERROR_HANDLER` environment variable is set and keeps error handling the way it used to work if that environment variable is not set.


---

**Why are there 2 PRs?**

This PR has a 'sister' PR https://github.com/chameleon-system/chameleon-base/pull/575 which removes the environment variable again since is should become the standard behaviour in 7.2 with the option of enabling it without BC-breaks in older releases.


* #565 adds an environment variable `USE_SYMFONY_CLI_ERROR_HANDLER` for symfony error handling
* #575 removes the environment variable and uses symfony error handling by default

The branches were created in a way that should allow merging without conflicts.

---

**Why add it to old versions in the first place?**

Switching to symfony error handling is mainly pushed by devops & automation which would be a lot easier, if CLI scripts returned a non-zero status code when they fail. symfony error handling does that by default.

---

**Why add it to an officially unsupported version (6.3)**

This change has a lot of benefit to the operations side of things. Updating from 6.3 to 7.0 can be a medium-sized undertaking - however updating older projects to a more recent 6.3.x release is easy and will make operations much easier for older projects. 
