### PR TITLE
ref #722: Correct type annotations

### DIFF
--- a/src/CmsCacheBundle/src/esono/pkgCmsCache/CacheInterface.php
+++ b/src/CmsCacheBundle/src/esono/pkgCmsCache/CacheInterface.php
@@ -34,7 +34,7 @@ interface CacheInterface
      *
      * @param string $key - key generated with GetKey
      *
-     * @return mixed - returns the cache object or null if not found
+     * @return mixed|null - returns the cache object or null if not found
      */
     public function get($key);
 
@@ -42,7 +42,7 @@ interface CacheInterface
      * adds or updates a cache object.
      *
      * @param string $key               - the cache key
-     * @param object $content           - object to be stored
+     * @param mixed  $content           - content to be stored
      * @param array  $trigger           - cache trigger array(array('table'=>'','id'=>''),array('table'=>'','id'=>''),...);
      * @param int    $iMaxLiveInSeconds - max age in seconds before the cache content expires - default = 30 days
      */

--- a/src/CoreBundle/private/core/TUserModelBaseCore.class.php
+++ b/src/CoreBundle/private/core/TUserModelBaseCore.class.php
@@ -19,7 +19,7 @@ class TUserModelBaseCore extends TModelBase
     /**
      * holds the instance id of the module (points to a record in the table cms_tpl_module_instance).
      *
-     * @var int
+     * @var string
      */
     public $instanceID = null;
 

--- a/src/CoreBundle/private/library/classes/DatabaseAccessLayer/EntityList.php
+++ b/src/CoreBundle/private/library/classes/DatabaseAccessLayer/EntityList.php
@@ -96,7 +96,7 @@ class EntityList implements EntityListInterface
     }
 
     /**
-     * @return array|bool
+     * @return array|false
      */
     public function current()
     {

--- a/src/CoreBundle/private/library/classes/TCMSFile/TCMSFileList.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFile/TCMSFileList.class.php
@@ -71,7 +71,7 @@ class TCMSFileList extends TIterator
      * @param string $sString
      * @param string $sPattern - regex
      *
-     * @return array|bool
+     * @return array|false
      */
     protected function StringMatchesPattern($sString, $sPattern)
     {
@@ -98,7 +98,7 @@ class TCMSFileList extends TIterator
     /**
      * returns the current item in the list and advances the list pointer by 1.
      *
-     * @return TCMSFile
+     * @return TCMSFile|false
      */
     public function &next()
     {
@@ -108,7 +108,7 @@ class TCMSFileList extends TIterator
     /**
      * returns the current item in the list and moves the list pointer back by 1.
      *
-     * @return TCMSFile
+     * @return TCMSFile|false
      */
     public function &Previous()
     {
@@ -118,7 +118,7 @@ class TCMSFileList extends TIterator
     /**
      * returns one random element from the list.
      *
-     * @return TCMSFile
+     * @return TCMSFile|false
      */
     public function &Random()
     {

--- a/src/CoreBundle/private/library/classes/TIterator.class.php
+++ b/src/CoreBundle/private/library/classes/TIterator.class.php
@@ -141,7 +141,7 @@ class TIterator
      * @param string $propertyValue - property value
      * @param bool   $bIgnoreCase   - do a case insenstive compare
      *
-     * @return object|bool
+     * @return object|false
      */
     public function FindItemWithProperty($propertyName, $propertyValue, $bIgnoreCase = false)
     {
@@ -267,7 +267,7 @@ class TIterator
     /**
      * returns the current item in the list and advances the list pointer by 1.
      *
-     * @return object
+     * @return object|false
      */
     public function &next()
     {
@@ -296,6 +296,8 @@ class TIterator
 
     /**
      * Resets the pointer back to the start of the list.
+     *
+     * @return void
      */
     public function GoToStart()
     {
@@ -305,6 +307,8 @@ class TIterator
 
     /**
      * Returns the number of elements in the list.
+     *
+     * @return int
      */
     public function Length()
     {
@@ -332,7 +336,7 @@ class TIterator
     /**
      * returns one random element from the list.
      *
-     * @return object|bool $item
+     * @return object|false $item
      */
     public function &Random()
     {
@@ -347,6 +351,7 @@ class TIterator
 
     /**
      * shuffle list.
+     * @return void
      */
     public function ShuffleList()
     {
@@ -356,6 +361,7 @@ class TIterator
 
     /**
      * reverses the item list.
+     * @return void
      */
     public function ReverseItemList()
     {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSContentBox.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSContentBox.class.php
@@ -30,6 +30,7 @@ class TCMSContentBox extends TAdbCmsContentBoxList
      * sets the users backend language for the menu items.
      *
      * @param string $query
+     * @return void
      */
     public function Load($query = null, array $queryParameters = array(), array $queryParameterTypes = array())
     {

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordList.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordList.class.php
@@ -118,7 +118,17 @@ class TCMSRecordList extends TIterator
     private $databaseConnection;
 
     protected $estimationLowerLimit;
+
+    /**
+     * PDO style parameters
+     * @var array
+     */
     private $queryParameters;
+
+    /**
+     * PDO style parameters types
+     * @var array
+     */
     private $queryParameterTypes;
 
     protected function getItemPointer()
@@ -488,6 +498,8 @@ class TCMSRecordList extends TIterator
      * @param string $sQuery
      * @param array  $queryParameters     - PDO style parameters
      * @param array  $queryParameterTypes - PDO style parameter types
+     *
+     * @return void
      */
     public function Load($sQuery, array $queryParameters = array(), array $queryParameterTypes = array())
     {
@@ -497,11 +509,17 @@ class TCMSRecordList extends TIterator
         $this->ResetList();
     }
 
+    /**
+     * @return array
+     */
     protected function getQueryParameters()
     {
         return $this->queryParameters;
     }
 
+    /**
+     * @return array
+     */
     protected function getQueryParameterTypes()
     {
         return $this->queryParameterTypes;
@@ -514,7 +532,7 @@ class TCMSRecordList extends TIterator
      * @param string $propertyName
      * @param string $propertyValue
      *
-     * @return bool|void
+     * @return void
      */
     public function RemoveItem($propertyName, $propertyValue)
     {
@@ -559,6 +577,8 @@ class TCMSRecordList extends TIterator
 
     /**
      * jumps to start of list.
+     *
+     * @return void
      */
     public function GoToStart()
     {
@@ -567,6 +587,8 @@ class TCMSRecordList extends TIterator
 
     /**
      * jump to end of list.
+     *
+     * @return void
      */
     public function GoToEnd()
     {
@@ -619,7 +641,7 @@ class TCMSRecordList extends TIterator
      * if we are at the end of the record, then the function will return false (like after GoToLast)
      * if we are at the start of the record (like after GoToStart), then it will return the first element.
      *
-     * @return TCMSRecord|bool
+     * @return TCMSRecord|false
      */
     public function &current()
     {
@@ -635,7 +657,7 @@ class TCMSRecordList extends TIterator
      * returns the next element from the list, moving the pointer to the next
      * record.
      *
-     * @return TCMSRecord|bool
+     * @return TCMSRecord|false
      */
     public function &next()
     {
@@ -654,7 +676,7 @@ class TCMSRecordList extends TIterator
     /**
      * returns the previous record from the list, moving the pointer back one.
      *
-     * @return TCMSRecord|bool
+     * @return TCMSRecord|false
      */
     public function &Previous()
     {
@@ -779,7 +801,7 @@ class TCMSRecordList extends TIterator
     /**
      * Returns the number of the page we're currently on.
      *
-     * @return integer: Page number
+     * @return int Page number
      */
     public function GetCurrentPageNumber()
     {
@@ -797,7 +819,7 @@ class TCMSRecordList extends TIterator
     /**
      * Returns the total number of pages in this list.
      *
-     * @return integer: Number of pages
+     * @return int Number of pages
      */
     public function GetTotalPageCount()
     {
@@ -896,6 +918,7 @@ class TCMSRecordList extends TIterator
      * Set or change the active list limit.
      *
      * @param int $iNewListLimit
+     * @return void
      */
     public function SetActiveListLimit($iNewListLimit)
     {

--- a/src/CoreBundle/private/library/classes/dbobjects/TDataMailProfile.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TDataMailProfile.class.php
@@ -133,7 +133,7 @@ class TDataMailProfile extends TDataMailProfileAutoParent
      * @param string $sProfileName
      * @param string $iLanguage
      *
-     * @return TdbDataMailProfile
+     * @return TdbDataMailProfile|null
      */
     public static function GetProfile($sProfileName, $iLanguage = null)
     {

--- a/src/CoreBundle/private/rendering/objectviews/TCMSTableToClass/recordList.view.php
+++ b/src/CoreBundle/private/rendering/objectviews/TCMSTableToClass/recordList.view.php
@@ -90,7 +90,7 @@ class <?=$sAutoClassName; ?>List extends TCMSRecordList
      * if we are at the end of the record, then the function will return false (like after GoToLast)
      * if we are at the start of the record (like after GoToStart), then it will return the first element
      *
-     * @return bool|<?php echo $sClassName."\n"; ?>
+     * @return <?php echo $sClassName."\n"; ?>
      */
     public function &Current()
     {
@@ -101,7 +101,7 @@ class <?=$sAutoClassName; ?>List extends TCMSRecordList
      * returns the next element from the list, moving the pointer to the next
      * record
      *
-     * @return bool|<?php echo $sClassName."\n"; ?>
+     * @return false|<?php echo $sClassName."\n"; ?>
      */
     public function &Next()
     {
@@ -111,7 +111,7 @@ class <?=$sAutoClassName; ?>List extends TCMSRecordList
     /**
      * returns the previous record from the list, moving the pointer back one
      *
-     * @return bool|<?php echo $sClassName."\n"; ?>
+     * @return false|<?php echo $sClassName."\n"; ?>
      */
     public function &Previous()
     {

--- a/src/ExtranetBundle/objects/db/TDataCountryList.class.php
+++ b/src/ExtranetBundle/objects/db/TDataCountryList.class.php
@@ -13,6 +13,8 @@ class TDataCountryList extends TDataCountryListAutoParent
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function Load($sQuery, array $queryParameters = array(), array $queryParameterTypes = array())
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#722   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Fixes a couple of type annotations, all within docblocks so IDEs and static analyzers can properly interpret the types.
