### PR TITLE
ref #715: Use symfony CLI error handling by default

### DIFF
--- a/src/CoreBundle/bin/console
+++ b/src/CoreBundle/bin/console
@@ -32,6 +32,14 @@ require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
+/**
+ * #715: Use symfony error handling, when `USE_SYMFONY_CLI_ERROR_HANDLER=1` is set but default to
+ *       old-style error handler.
+ * @deprecated This flag exists to ease the move to symfony error handling.
+ *             It will be removed in the future and symfony error handling will become standard with 7.2
+ */
+$useSymfonyCliErrorHandler = '1' === getenv('USE_SYMFONY_CLI_ERROR_HANDLER');
+
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('--no-debug', '')) && 'prod' !== $env;
@@ -39,7 +47,9 @@ $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('-
 try {
     $kernel = new AppKernel($env, $debug);
     $application = new Application($kernel);
-    $application->setCatchExceptions(false);
+    if (false === $useSymfonyCliErrorHandler) {
+        $application->setCatchExceptions(false);
+    }
     $application->run($input);
 } catch (Exception $e) {
     echo $e;

--- a/src/CoreBundle/bin/console
+++ b/src/CoreBundle/bin/console
@@ -32,25 +32,10 @@ require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
-/**
- * #715: Use symfony error handling, when `USE_SYMFONY_CLI_ERROR_HANDLER=1` is set but default to
- *       old-style error handler.
- * @deprecated This flag exists to ease the move to symfony error handling.
- *             It will be removed in the future and symfony error handling will become standard with 7.2
- */
-$useSymfonyCliErrorHandler = '1' === getenv('USE_SYMFONY_CLI_ERROR_HANDLER');
-
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption(array('--no-debug', '')) && 'prod' !== $env;
 
-try {
-    $kernel = new AppKernel($env, $debug);
-    $application = new Application($kernel);
-    if (false === $useSymfonyCliErrorHandler) {
-        $application->setCatchExceptions(false);
-    }
-    $application->run($input);
-} catch (Exception $e) {
-    echo $e;
-}
+$kernel = new AppKernel($env, $debug);
+$application = new Application($kernel);
+$application->run($input);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | yes     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#715   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Before this change, symfony exception handling was disabled in the CLI in favour of a simple `echo` call.
This enables symfony exception handling for CLI commands, which brings 2 welcome improvements:

1. It fixes chameleon-system/chameleon-system#715 since symfony will already exit with a non-zero status code when an exception occurs (It will use the `code` of the exception or `1` if that doesn't exist).
2. Exception rendering on the CLI is consistent with other symfony applications (See Screenshots at the bottom of this description)

### BC Breaks
At the moment failing console commands will not cause some automation tools (e.g. `make`) to fail if an error occurs since the exit code is still `0`. This change will change that behaviour and thus, automation tolos invoking console commands may change their behaviour in error cases.

### Rendering changes

Rendering changes mentioned above:

*Before:*
![2021-07-02_17-46](https://user-images.githubusercontent.com/3374170/124299249-7ff2eb80-db5d-11eb-9805-644b36985b90.png)

*After (with 2 different verbosity levels):*
![2021-07-02_17-46_1](https://user-images.githubusercontent.com/3374170/124299247-7f5a5500-db5d-11eb-90ee-1fb026ee61ef.png)



---

**Why are there 2 PRs?**

This PR has a 'sister' PR #565 which adds the new behaviour behind an environment variable to avoid BC-breaks in older releases.

* #565 adds an environment variable `USE_SYMFONY_CLI_ERROR_HANDLER` for symfony error handling
* #575 removes the environment variable and uses symfony error handling by default

The branches were created in a way that should allow merging without conflicts.

