### PR TITLE
ref #726: Make methods static

### DIFF
--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
@@ -2245,15 +2245,15 @@ class TCMSRecord implements IPkgCmsSessionPostWakeupListener
         return array($tdbClassName, $cellFormattingFunctionName);
     }
 
-    public function callBackUuid(string $id)
+    public static function callBackUuid(string $id): string
     {
         return '<span title="'.TGlobal::OutHTML($id).'"><i class="fas fa-fingerprint"></i> '.self::getShortUuid($id).'</span>';
     }
 
-    protected function getShortUuid(string $uuid)
+    protected static function getShortUuid(string $uuid): string
     {
         if (strlen($uuid) > 8) {
-            return substr($uuid, 0, 8);
+            return (string) substr($uuid, 0, 8);
         }
 
         return $uuid;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#726   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Calling non-static methods statically is not allowed anymore in PHP8. This changes `TCMSRecord::callBackUuid` to be a static method. This should be safe since the only invocation of it I could find comes from that same class in `TCMSRecord::getCellFormattingFunction`. While I was changing the methods I added return type annotations since they are fairly straight forward in this case.