### PR TITLE
ref #725: Replace `each` function usage with `foreach`

### DIFF
--- a/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
@@ -612,7 +612,6 @@ class TFullGroupTable extends TGroupTable
                     if (isset($this->orderList) && is_array($this->orderList) && array_key_exists($cellObj->name, $this->orderList)) {
                         // find orderCount
                         $orderCount = 1;
-                        $found = false;
                         reset($this->orderList);
 
                         $tmpOrderList = $this->orderList;
@@ -626,7 +625,6 @@ class TFullGroupTable extends TGroupTable
                             if (0 != strcmp($cellObj->name, $field)) {
                                 ++$orderCount;
                             } else {
-                                $found = true;
                                 break;
                             }
                         }

--- a/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
+++ b/src/CoreBundle/private/library/classes/TFullGroupTable/TFullGroupTable.class.php
@@ -622,11 +622,12 @@ class TFullGroupTable extends TGroupTable
                             unset($tmpOrderList[$this->groupByCell->name]);
                         }
 
-                        while ((list($field, $dir) = each($tmpOrderList)) && !$found) {
+                        foreach ($tmpOrderList as $field => $dir) {
                             if (0 != strcmp($cellObj->name, $field)) {
                                 ++$orderCount;
                             } else {
                                 $found = true;
+                                break;
                             }
                         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#725   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Replaces a usage of the `each` function which was removed in PHP8 with it's `foreach` equivalent.