### PR TITLE
ref #724: Check if value is string before unserializing

### DIFF
--- a/src/CoreBundle/private/rendering/objectviews/TCMSFields/TCMSFieldBlob/postload.view.php
+++ b/src/CoreBundle/private/rendering/objectviews/TCMSFields/TCMSFieldBlob/postload.view.php
@@ -10,7 +10,7 @@ if (isset($oDefinition->sqlData['is_translatable']) && '1' == $oDefinition->sqlD
 ?>
     if ($this->sqlData['<?= $sFieldDatabaseName; ?>'] === serialize(false)) {
         $this->sqlData['<?= $sFieldDatabaseName; ?>'] = false;  // special case - false was serialized
-    } else {
+    } elseif(is_string($this->sqlData['<?= $sFieldDatabaseName; ?>'])) {
         $sTmpCleanData = @unserialize($this->sqlData['<?= $sFieldDatabaseName; ?>']);
         if ($sTmpCleanData !== false) {
             $this->sqlData['<?= $sFieldDatabaseName; ?>'] = $sTmpCleanData;

--- a/src/CoreBundle/private/rendering/objectviews/TCMSFields/TCMSFieldEncodedData/postload.view.php
+++ b/src/CoreBundle/private/rendering/objectviews/TCMSFields/TCMSFieldEncodedData/postload.view.php
@@ -21,7 +21,7 @@ if($sDecodedData == '') {
 $sDecodedData = $this->sqlData['<?= $sFieldDatabaseName; ?>'];
 }else{
 if ($sDecodedData === serialize(false)) $sDecodedData = false; // special case - false was serialized
-else {
+elseif (is_string($sDecodedData)) {
 $sTmpCleanData = @unserialize($sDecodedData);
 if ($sTmpCleanData !== false) {
 $sDecodedData = $sTmpCleanData;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#724   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In PHP8, attempting to unserialize a non-string (such as an array in this case, as the value has been previously unserialized) raises a TypeError as opposed to a warning in PHP7.4. This adds checks to the two instances I have found where this is an issue.