### PR TITLE
ref #728: Fix incorrect alert for TCMSFieldDateToday

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateToday.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldDateToday.class.php
@@ -9,6 +9,9 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Translation\TranslatorInterface;
+use ChameleonSystem\CoreBundle\ServiceLocator;
+
 /**
  * todays date (editable).
 /**/
@@ -33,7 +36,14 @@ class TCMSFieldDateToday extends TCMSFieldDate
         $html = parent::GetHTML();
 
         if ($this->currentDateIsEmpty) {
-            $html .= '<span class="alert alert-info">'.TGlobal::Translate('chameleon_system_core.field_date_time.not_set').'</span>';
+            $html = sprintf(
+                '
+                    <div class="alert alert-info">%s</div>
+                    %s
+                ',
+                $this->getTranslator()->trans('chameleon_system_core.field_date_time.not_set'),
+                $html
+            );
         }
 
         return $html;
@@ -48,5 +58,10 @@ class TCMSFieldDateToday extends TCMSFieldDate
         }
 
         return $htmldate;
+    }
+
+    private function getTranslator(): TranslatorInterface
+    {
+        return ServiceLocator::get('translator');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#728   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

* Uses a `div` instead of a `span` to fix overlapping issues associated with `span.alert`
* Flips the order of field & alert around to be consistent with other fields that display the alert above the field
* Fetches the translator service from ServiceLocator instead of using deprecated `TGlobal::Translate`