### PR TITLE
ref #741: press Enter in last textfield of a tab saves the record, bu…

### DIFF
--- a/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
@@ -3,7 +3,6 @@
 use ChameleonSystem\CoreBundle\ServiceLocator;
 use ChameleonSystem\CoreBundle\Util\UrlNormalization\UrlNormalizationUtil;
 
-$sLastTextFieldName = '';
 $data['oFields']->GoToStart();
 $sTmpFormTabsContent = '';
 while ($oField = $data['oFields']->Next()) {
@@ -56,14 +55,7 @@ while ($oField = $data['oFields']->Next()) {
                 }
 
                 if (ACTIVE_TRANSLATION) {
-                    $lastFieldIsTextField = false;
-                    $aAllowedTypes = ['CMSFIELD_STRING', 'CMSFIELD_STRING_UNIQUE'];
                     $oFieldType = $oField->oDefinition->GetFieldType();
-                    if (in_array($oFieldType->sqlData['constname'], $aAllowedTypes)) {
-                        $lastFieldIsTextField = true;
-                        $sLastTextFieldName = $oField->name;
-                    }
-
                     if ('1' === $oField->oDefinition->sqlData['is_translatable']) {
                         $sPrefix = TGlobal::GetLanguagePrefix($oTable->GetLanguage());
                         if (empty($sPrefix)) {
@@ -126,21 +118,4 @@ if (!empty($sTmpFormTabsContent)) {
     $sFormTabsContent .= '<div class="mt-3">';
     $sFormTabsContent .= $sTmpFormTabsContent;
     $sFormTabsContent .= '</div></div>';
-}
-
-/** add handling of ENTER key to trigger the save button if we have a form with a text field as last field */
-if (true === $lastFieldIsTextField && '' !== $sLastTextFieldName) {
-    ?>
-<script type="text/javascript">
-    $(document).ready(function () {
-        $('#<?=$sLastTextFieldName; ?>').keypress(function (e) {
-            code = e.keyCode ? e.keyCode : e.which;
-            if (code.toString() == 13) { // ENTER key
-                e.preventDefault();
-                $('.button-element button.itemsave').click();
-            }
-        });
-    });
-</script>
-<?php
 }

--- a/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/views/includes/fields.inc.php
@@ -3,7 +3,6 @@
 use ChameleonSystem\CoreBundle\ServiceLocator;
 use ChameleonSystem\CoreBundle\Util\UrlNormalization\UrlNormalizationUtil;
 
-$iTextFieldCount = 0;
 $sLastTextFieldName = '';
 $data['oFields']->GoToStart();
 $sTmpFormTabsContent = '';
@@ -57,13 +56,12 @@ while ($oField = $data['oFields']->Next()) {
                 }
 
                 if (ACTIVE_TRANSLATION) {
-                    $bIsTextField = false;
-                    $aAllowedTypes = array('CMSFIELD_STRING', 'CMSFIELD_TEXT', 'CMSFIELD_STRING_UNIQUE');
+                    $lastFieldIsTextField = false;
+                    $aAllowedTypes = ['CMSFIELD_STRING', 'CMSFIELD_STRING_UNIQUE'];
                     $oFieldType = $oField->oDefinition->GetFieldType();
                     if (in_array($oFieldType->sqlData['constname'], $aAllowedTypes)) {
-                        $bIsTextField = true;
+                        $lastFieldIsTextField = true;
                         $sLastTextFieldName = $oField->name;
-                        ++$iTextFieldCount;
                     }
 
                     if ('1' === $oField->oDefinition->sqlData['is_translatable']) {
@@ -130,8 +128,8 @@ if (!empty($sTmpFormTabsContent)) {
     $sFormTabsContent .= '</div></div>';
 }
 
-/** add handling of ENTER key to trigger the save button if we have a form with only one text field */
-if (!empty($sLastTextFieldName) && 1 == $iTextFieldCount) {
+/** add handling of ENTER key to trigger the save button if we have a form with a text field as last field */
+if (true === $lastFieldIsTextField && '' !== $sLastTextFieldName) {
     ?>
 <script type="text/javascript">
     $(document).ready(function () {
@@ -139,7 +137,7 @@ if (!empty($sLastTextFieldName) && 1 == $iTextFieldCount) {
             code = e.keyCode ? e.keyCode : e.which;
             if (code.toString() == 13) { // ENTER key
                 e.preventDefault();
-                $('.btn-group button.itemsave').click();
+                $('.button-element button.itemsave').click();
             }
         });
     });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#741...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The handling to "save the record if Enter key is pressed in last text field" works again.
There was a wrong class selector in query selector (selector changed with Chameleon 7.0).
But these handling never makes sense for textareas (CMSFIELD_TEXT), because textareas have mostly several lines. So I removed it from $aAllowedTypes.

Furthermore, it should not only be the last **text** field, but the last field of Tab in general to save the form on event enter-key. 
I have also changed this.

