### PR TITLE
ref #747: Enable symfony debug error handler if in devmode

### DIFF
--- a/src/CoreBundle/FrontController/app.php
+++ b/src/CoreBundle/FrontController/app.php
@@ -39,9 +39,9 @@ require_once PATH_PROJECT_BASE.'/app/AppKernel.php';
 
 $devmode = defined('_DEVELOPMENT_MODE') && _DEVELOPMENT_MODE === true;
 $env = $devmode ? 'dev' : 'prod';
-//if($devmode) {
-//    Symfony\Component\Debug\Debug::enable(null, false);
-//}
+if($devmode) {
+    Symfony\Component\ErrorHandler\Debug::enable();
+}
 
 $kernel = new AppKernel($env, $devmode);
 $request = Request::createFromGlobals();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#747   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Enables debug error handling in order to get stack traces for exceptions. The call of `Debug::enable` mirrors the default `index.php` one would get with a new Symfony project