### PR TITLE
749 make compatible with php 81: static cell format function

### DIFF
--- a/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
+++ b/src/CoreBundle/private/library/classes/TGroupTable/TGroupTableField.class.php
@@ -424,19 +424,15 @@ class TGroupTableField
         if (is_array($format)) {
             $classNameOrObject = $format[0];
             $callbackFunctionName = $format[1];
+            $className = true === \is_string($classNameOrObject) ? $classNameOrObject : \get_class($classNameOrObject);
 
-            $callableObject = $classNameOrObject;
-            if (\is_string($classNameOrObject)) {
-                $callableObject = new $classNameOrObject; // TODO wip this unsolicited new on anything is problematic
-                // Or directly support calling (static) methods of classes?
+            if (false === is_callable([$classNameOrObject, $callbackFunctionName])) {
+                return sprintf('[Error: function "%s" is not present or callable in "%s" for field "%s"]', $callbackFunctionName, $className, $name);
             }
 
-            if (false === is_callable(array($callableObject, $callbackFunctionName))) {
-                return sprintf('[Error: function "%s" is not present or callable in "%s" for field "%s"]', $callbackFunctionName, \get_class($callableObject), $name);
-            }
-
-            return call_user_func(array($callableObject, $callbackFunctionName), $cellValue, $row, $name);
+            return call_user_func([$classNameOrObject, $callbackFunctionName], $cellValue, $row, $name);
         }
+
         if (function_exists($format)) {
             return call_user_func($format, $cellValue, $row, $name);
         }

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecord.class.php
@@ -2245,12 +2245,12 @@ class TCMSRecord implements IPkgCmsSessionPostWakeupListener
         return array($tdbClassName, $cellFormattingFunctionName);
     }
 
-    public function callBackUuid(string $id)
+    public static function callBackUuid(string $id)
     {
         return '<span title="'.TGlobal::OutHTML($id).'"><i class="fas fa-fingerprint"></i> '.self::getShortUuid($id).'</span>';
     }
 
-    protected function getShortUuid(string $uuid)
+    protected static function getShortUuid(string $uuid)
     {
         if (strlen($uuid) > 8) {
             return substr($uuid, 0, 8);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no - probably no-one uses the accidental feature of #423 that a non-static method can be specified as cell format function in a static notation
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#749
| License       | MIT
