### PR TITLE
Convert possible integer type to be a string for equation…

### DIFF
--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookup.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookup.html.twig
@@ -12,7 +12,7 @@
                 <option value="">{{ 'chameleon_system_core.form.select_box_nothing_selected'|trans }}</option>
             {% endif %}
             {% for key, option in options %}
-                {% if key == connectedRecordId %}
+                {% if key ~ '' == connectedRecordId %}
                     {% set selected = 'selected' %}
                 {% else %}
                     {% set selected = '' %}

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookupFieldTypes.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldLookup/fieldLookupFieldTypes.html.twig
@@ -8,7 +8,7 @@
                 data-select2-option='{{ selectOptions|e('html_attr') }}'>
             {% set helpText = "" %}
             {% for key, option in options %}
-                {% if key == connectedRecordId %}
+                {% if key ~ '' == connectedRecordId %}
                     {% set selected = "selected" %}
                     {% set helpText = fieldsHelpText[key] %}
                 {% else %}


### PR DESCRIPTION
… test, avoiding a conversion of a string id to an integer

| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#758
| License       | MIT

Fixes Twig ver. 2 comparison behaviour of PHP when comparing numbers and strings.
