### PR TITLE
ref #653: Always only have \n as line ending (after save)

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldText.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldText.class.php
@@ -86,4 +86,18 @@ class TCMSFieldText extends TCMSField
 
         return $bHasContent;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function ConvertPostDataToSQL()
+    {
+        $data = parent::ConvertPostDataToSQL();
+
+        // make sure line endings are always consistent (simple \n)
+        $data = \str_replace("\r\n", "\n", $data);
+        $data = \str_replace("\r", "\n", $data);
+
+        return $data;
+    }
 }

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldWYSIWYG.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldWYSIWYG.class.php
@@ -711,6 +711,20 @@ class TCMSFieldWYSIWYG extends TCMSFieldText
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function ConvertPostDataToSQL()
+    {
+        $data = parent::ConvertPostDataToSQL();
+
+        // make sure line endings are always consistent (simple \n)
+        $data = \str_replace("\r\n", "\n", $data);
+        $data = \str_replace("\r", "\n", $data);
+
+        return $data;
+    }
+
+    /**
      * @param $sEditorHeight
      */
     protected function setEditorHeight($sEditorHeight)

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldWYSIWYG.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldWYSIWYG.class.php
@@ -711,20 +711,6 @@ class TCMSFieldWYSIWYG extends TCMSFieldText
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function ConvertPostDataToSQL()
-    {
-        $data = parent::ConvertPostDataToSQL();
-
-        // make sure line endings are always consistent (simple \n)
-        $data = \str_replace("\r\n", "\n", $data);
-        $data = \str_replace("\r", "\n", $data);
-
-        return $data;
-    }
-
-    /**
      * @param $sEditorHeight
      */
     protected function setEditorHeight($sEditorHeight)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes probably no: anything that relies on \r\n being present
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#653
| License       | MIT


