### PR TITLE
456 catch mapper exceptions in prod

### DIFF
--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -126,6 +126,7 @@
             <argument type="service" id="chameleon_system_core.global" />
             <argument />  <!-- Module execution strategy will be set by ChameleonSystemCoreExtension -->
             <argument type="service" id="chameleon_system_core.request_info_service"/>
+            <argument type="service" id="logger"/>
         </service>
         <service id="chameleon_system_core.usermoduleloader" class="TUserModuleLoader" parent="chameleon_system_core.moduleloader" public="true" />
 

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -713,6 +713,7 @@
 
         <service id="chameleon_system_core.mapper_loader" class="ChameleonSystem\CoreBundle\MapperLoader\MapperLoader" public="true">
             <argument /> <!-- Will be set by AddMappersPass. -->
+            <argument type="service" id="logger"/>
         </service>
 
         <service id="chameleon_system_core.field.provider.class_from_table_field" class="ChameleonSystem\CoreBundle\Field\Provider\ClassFromTableFieldProvider" public="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#456
| License       | MIT

Missing mappers in prod are now also only logged (as critical).
If there are subsequent exceptions because of this, they are already caught by the TModuleLoader.
Changed the logging there (simpler but cricitcal message also for this).