### PR TITLE
run composer du

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
 
       # Chameleon setup
       - run: |
+          composer dumpautoload
           php app/console chameleon_system:autoclasses:generate
           php app/console chameleon_system:update:run
         working-directory: chameleon-system


### PR DESCRIPTION
In order to detect new core classes not covered by PSR-4 run composer du again after replacing the core

