### PR TITLE
ref #749: Fix `ProfilerStatement` being incompatible with PHP8+

### DIFF
--- a/src/DebugBundle/Statement/ProfilerStatement.php
+++ b/src/DebugBundle/Statement/ProfilerStatement.php
@@ -145,15 +145,16 @@ class ProfilerStatement extends PDOStatement
     }
 
     /**
-     * @param int|null $fetch_style
-     * @param mixed $fetch_argument
-     * @param mixed $ctor_args
-     * @return mixed[]
+     * @psalm-suppress MethodSignatureMismatch - This method extends {@see PDOStatementImplementations} which differs depending on
+     *     the PHP version: PDOStatementImplementations::fetchAll has different signatures in 7.4 to 8.0. For this reason there is
+     *     no definitive declaration to be compatible with both. Since we are only passing down the arguments, passing all of them
+     *     down is a compromise in this case.
+     * @FIXME Use correct method signature once PHP7.4 support is being dropped.
      */
-    public function fetchAll($fetch_style = null, $fetch_argument = null, $ctor_args = null)
+    public function fetchAll(...$args)
     {
         $startTime = microtime(true);
-        $result = $this->statement->fetchAll($fetch_style, $fetch_argument, $ctor_args);
+        $result = $this->statement->fetchAll(...$args);
         $this->databaseConnection->addToQueryTimer(microtime(true) - $startTime);
 
         return $result;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features / 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#749   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Currently, the `ProfilerStatement::fetchAll` method is not compatible with it's parent in PHP8+. This is due to the actual implementation of the method being switched out in dbal: https://github.com/doctrine/dbal/blob/2.13.9/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php

I could not find a way to be compatible with both declarations at the same time without resorting to `...$args`