### PR TITLE
415/better error handling in module loading

### DIFF
--- a/src/CoreBundle/private/core/TModuleLoader.class.php
+++ b/src/CoreBundle/private/core/TModuleLoader.class.php
@@ -353,7 +353,7 @@ class TModuleLoader
             $this->logModuleException($e, $spotName);
         } catch (\Exception $e) {
             if (_DEVELOPMENT_MODE) {
-                throw new ModuleExecutionFailedException('Error in module execution: '.$e->getMessage().' in file: '.$e->getFile().' on line: '.$e->getLine(), 0, $e);
+                throw new ModuleExecutionFailedException(sprintf('Error in module execution: %s in file: %s on line: %d',$e->getMessage(), $e->getFile(), $e->getLine()), 0, $e);
             }
 
             $this->logModuleException($e, $spotName);

--- a/src/CoreBundle/private/core/TModuleLoader.class.php
+++ b/src/CoreBundle/private/core/TModuleLoader.class.php
@@ -353,7 +353,7 @@ class TModuleLoader
             $this->logModuleException($e, $spotName);
         } catch (\Exception $e) {
             if (_DEVELOPMENT_MODE) {
-                throw new ModuleExecutionFailedException('Error in module execution: '.$e->getMessage(), 0, $e);
+                throw new ModuleExecutionFailedException('Error in module execution: '.$e->getMessage().' in file: '.$e->getFile().' on line: '.$e->getLine(), 0, $e);
             }
 
             $this->logModuleException($e, $spotName);

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTPLModule.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTPLModule.class.php
@@ -210,7 +210,13 @@ class TCMSTPLModule extends TCMSRecord
         if (null !== $viewMapperConfig) {
             return $viewMapperConfig;
         }
-        $viewMapperConfig = new ViewMapperConfig($this->sqlData['view_mapper_config']);
+
+        try {
+            $viewMapperConfig = $this->sqlData['view_mapper_config'];
+        } catch (\Exception $e) {
+            throw new \Exception(sprintf('module with ID: %s not found',$this->id));
+        }
+        $viewMapperConfig = new ViewMapperConfig($viewMapperConfig);
         $this->SetInternalCache('viewMapperConfig', $viewMapperConfig);
 
         return $viewMapperConfig;

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTPLModule.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTPLModule.class.php
@@ -211,9 +211,9 @@ class TCMSTPLModule extends TCMSRecord
             return $viewMapperConfig;
         }
 
-        try {
+        if (false !== $this->sqlData && \array_key_exists('view_mapper_config', $this->sqlData)) {
             $viewMapperConfig = $this->sqlData['view_mapper_config'];
-        } catch (\Exception $e) {
+        } else {
             throw new \Exception(sprintf('module with ID: %s not found',$this->id));
         }
         $viewMapperConfig = new ViewMapperConfig($viewMapperConfig);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#415
| License       | MIT

Adds better exception handling if a module is configured to an ID that does not exist as module.
This may happen if a theme is installed.

