### PR TITLE
791 iterator

### DIFF
--- a/src/CoreBundle/Tests/private/library/classes/DatabaseAccessLayer/EntityListTest.php
+++ b/src/CoreBundle/Tests/private/library/classes/DatabaseAccessLayer/EntityListTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+use ChameleonSystem\core\DatabaseAccessLayer\EntityList;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EntityListTest extends TestCase
+{
+    /** @var EntityList */
+    private $subject;
+
+    /** @var MockObject<Connection> */
+    private $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->subject = new EntityList(
+            $this->connection, 'SELECT * FROM foo'
+        );
+    }
+
+    public function testEntityList(): void
+    {
+        $result = $this->createMock(Statement::class);
+        $result->method('fetch')->willReturnOnConsecutiveCalls(1, 2, 3, false);
+        $this->connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        // Iterating multiple times checks if `rewind` behaves correctly
+        $items = [ ];
+        foreach ($this->subject as $item) {
+            $items[] = $item;
+        }
+        foreach ($this->subject as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertEquals([ 1, 2, 3, 1, 2, 3 ], $items);
+    }
+
+}

--- a/src/CoreBundle/Tests/private/library/classes/TIteratorTest.php
+++ b/src/CoreBundle/Tests/private/library/classes/TIteratorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 use PHPUnit\Framework\TestCase;
 
 class TIteratorTest extends TestCase
@@ -150,9 +149,25 @@ class TIteratorTest extends TestCase
                     $this->assertEquals('baz', $item);
                     break;
                 default:
-                    throw new \Exception('Invalid index ' . index);
+                    throw new \Exception('Invalid index ' . $index);
             }
         }
+    }
+
+    public function testCanBeIteratedMultipleTimes(): void
+    {
+        // Tests if the `reset` method correctly resets the item pointer
+        $iterator = $this->iterator([ 'foo', 'bar', 'baz' ]);
+
+        $items = [ ];
+        foreach ($iterator as $item) {
+            $items[] = $item;
+        }
+        foreach ($iterator as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertEquals([ 'foo', 'bar', 'baz', 'foo', 'bar', 'baz' ], $items);
     }
 
     public function testResetsItemPointerBeforeIterating(): void

--- a/src/CoreBundle/Tests/private/library/classes/dbobjects/TCMSRecordListTest.php
+++ b/src/CoreBundle/Tests/private/library/classes/dbobjects/TCMSRecordListTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+require_once __DIR__ . '/mocks/EntityListMock.php';
+
+use ChameleonSystem\core\DatabaseAccessLayer\EntityList;
+use ChameleonSystem\core\DatabaseAccessLayer\EntityListInterface;
+use ChameleonSystem\core\DatabaseAccessLayer\QueryModifierOrderByInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use mocks\EntityListMock;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TCMSRecordListTest extends TestCase
+{
+    /** @var EntityListInterface */
+    public static $entityList;
+
+    /** @var MockObject<QueryModifierOrderByInterface> */
+    public static $queryModifier;
+
+    /** @var MockObject<Connection> */
+    private $connection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->createMock(Connection::class);
+    }
+
+    public function testIterates(): void
+    {
+        self::$entityList = new EntityListMock([ 1, 2, 3 ]);
+        $list = $this->mockRecordList();
+
+        // Iterating multiple times checks if `rewind` behaves correctly
+        $items = [ ];
+        foreach ($list as $item) {
+            $items[] = $item;
+        }
+        foreach ($list as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertEquals([ 1, 2, 3, 1, 2, 3 ], $items);
+    }
+
+    public function testIteratesInCombinationWithEntityList(): void
+    {
+        self::$queryModifier = $this->createMock(QueryModifierOrderByInterface::class);
+        self::$queryModifier->method('getQueryWithOrderBy')->willReturnArgument(0);
+        self::$queryModifier->method('getQueryWithoutOrderBy')->willReturnArgument(0);
+
+        self::$entityList = new class ($this->connection, 'SELECT * FROM foo') extends EntityList {
+            protected function getQueryModifierOrderByService() {
+                return TCMSRecordListTest::$queryModifier;
+            }
+        };
+
+        $list = $this->mockRecordList();
+
+        // The data that should be iterated is supplied by mocking the database connection
+        // inside the entitylist itself.
+        $result = $this->createMock(Statement::class);
+        $result->method('fetch')->willReturnOnConsecutiveCalls(1, 2, 3, false);
+        $this->connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($result);
+        $this->connection
+            ->method('fetchArray')
+            ->with($this->matchesRegularExpression('/COUNT\(\*\)/'))
+            ->willReturn([ 3 ]);
+
+        // Iterating multiple times checks if `rewind` behaves correctly
+        $items = [ ];
+        foreach ($list as $item) {
+            $items[] = $item;
+        }
+        foreach ($list as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertEquals([ 1, 2, 3, 1, 2, 3 ], $items);
+    }
+
+    /**
+     * Assumes, that `entityList` was set before
+     */
+    private function mockRecordList(): TCMSRecordList
+    {
+        return new class extends TCMSRecordList {
+
+            // Mocks away container parameter
+            protected $estimationLowerLimit = 0;
+
+            // Swaps out the iterator to a mock
+            protected function getEntityList() {
+                return TCMSRecordListTest::$entityList;
+            }
+
+            // Does not create a new Tdb for the data returned from the iterator
+            // but returns the data 1:1
+            protected function &_NewElement(&$aData) {
+                return $aData;
+            }
+        };
+    }
+
+}

--- a/src/CoreBundle/Tests/private/library/classes/dbobjects/mocks/EntityListMock.php
+++ b/src/CoreBundle/Tests/private/library/classes/dbobjects/mocks/EntityListMock.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace mocks;
+
+use ChameleonSystem\core\DatabaseAccessLayer\EntityListInterface;
+use function count;
+
+class EntityListMock implements EntityListInterface
+{
+
+    public array $items;
+    public int $pointer = 0;
+
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function next()
+    {
+        $this->pointer++;
+    }
+
+    public function valid()
+    {
+        return $this->pointer < count($this->items);
+    }
+
+    public function rewind()
+    {
+        $this->pointer = 0;
+    }
+
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    public function getCurrentPosition()
+    {
+        return $this->pointer;
+    }
+
+    public function end()
+    {
+        $this->pointer = count($this->items) - 1;
+    }
+
+    public function setQuery($query)
+    {
+        // Does nothing
+    }
+
+    public function previous()
+    {
+        $this->pointer--;
+    }
+
+    public function estimateCount()
+    {
+        return count($this->items);
+    }
+
+    public function setPageSize($pageSize)
+    {
+        // Does nothing
+    }
+
+    public function setCurrentPage($currentPage)
+    {
+        // Does nothing
+    }
+
+    public function setMaxAllowedResults($maxNumberOfResults)
+    {
+        // Does nothing
+    }
+
+    public function seek(int $offset)
+    {
+        $this->pointer = $offset;
+    }
+
+    public function current()
+    {
+        return $this->items[$this->pointer];
+    }
+
+    public function key()
+    {
+        return $this->pointer;
+    }
+}

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordList.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSRecordList.class.php
@@ -711,6 +711,21 @@ class TCMSRecordList extends TIterator
         return $this->getItem($itemKey, $data);
     }
 
+    public function key(): int
+    {
+        return $this->getEntityList()->key();
+    }
+
+    public function valid(): bool
+    {
+        return $this->getEntityList()->valid();
+    }
+
+    public function rewind(): void
+    {
+        $this->getEntityList()->rewind();
+    }
+
     /**
      * returns the previous record from the list, moving the pointer back one.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#791   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Forwards iterator calls to `EntityList` instead of falling back to the implementation in `TIterator` that isn't used. While `TCMSRecordList` extends `TIterator`, most of it's functionality isn't actually used: Most of it's functionality is handed over to another Iterator, the `EntityList`.

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes, too).
 - Features and deprecations must be submitted against the master branch.
-->

