### PR TITLE
use different session for different portals

### DIFF
--- a/CHANGELOG-7.1.md
+++ b/CHANGELOG-7.1.md
@@ -3,8 +3,17 @@ CHANGELOG For 7.1.x
 
 # New Features
 
+In v7.1.4 there are separate sessions created for frontend and backend.
+If `CHAMELEON_EXTRANET_USER_IS_PORTAL_DEPENDANT` is set to `true`, each portal will have its own session as well.
+
 # Changed Features
 
 ## Field Type "Document manager" extends `TCMSFieldLookupMultiselect`
 
 This changes public methods - especially `GetMLTTableName`.
+
+# Changed Interfaces
+
+In v7.1.4 `\ChameleonSystem\CoreBundle\Service\RequestInfoServiceInterface` has an additional method:
+`isPreviewMode();`
+Implementations should return true if the current request is a frontend request and the current page is a preview page.

--- a/CHANGELOG-7.1.md
+++ b/CHANGELOG-7.1.md
@@ -16,4 +16,4 @@ This changes public methods - especially `GetMLTTableName`.
 
 In v7.1.4 `\ChameleonSystem\CoreBundle\Service\RequestInfoServiceInterface` has an additional method:
 `isPreviewMode();`
-Implementations should return true if the current request is a frontend request and the current page is a preview page.
+Implementations should return true if the current request is a frontend request and the preview mode is active.

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -99,7 +99,6 @@
             <argument type="service" id="service_container" />
             <argument>%session.metadata.update_threshold%</argument>
             <argument>%session.storage.options%</argument>
-            <argument type="service" id="chameleon_system_core.util.input_filter" />
             <argument type="service" id="chameleon_system_core.portal_domain_service" />
             <argument type="service" id="chameleon_system_core.request_info_service" />
             <argument type="service" id="logger" />

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -101,6 +101,8 @@
             <argument>%session.storage.options%</argument>
             <argument type="service" id="chameleon_system_core.util.input_filter" />
             <argument type="service" id="chameleon_system_core.portal_domain_service" />
+            <argument type="service" id="chameleon_system_core.request_info_service" />
+            <argument type="service" id="logger" />
         </service>
 
         <service id="session" synthetic="true" public="true"/>

--- a/src/CoreBundle/Resources/config/services.xml
+++ b/src/CoreBundle/Resources/config/services.xml
@@ -100,6 +100,7 @@
             <argument>%session.metadata.update_threshold%</argument>
             <argument>%session.storage.options%</argument>
             <argument type="service" id="chameleon_system_core.util.input_filter" />
+            <argument type="service" id="chameleon_system_core.portal_domain_service" />
         </service>
 
         <service id="session" synthetic="true" public="true"/>

--- a/src/CoreBundle/Service/RequestInfoService.php
+++ b/src/CoreBundle/Service/RequestInfoService.php
@@ -146,7 +146,7 @@ class RequestInfoService implements RequestInfoServiceInterface
             return false;
         }
 
-        // todo: `__rpeviewmode` should be the only way to enable this. Refactor all places where the preview attribute is set as `preview` instead of `__previewmode'
+        // todo: `__previewmode` should be the only way to enable this. Refactor all places where the preview attribute is set as `preview` instead of `__previewmode'
         $this->isPreviewModeCache = false === \TGlobal::IsCMSMode() &&
             ('true' === $request->get('__previewmode') || 'true' === $request->get('preview'));
 

--- a/src/CoreBundle/Service/RequestInfoService.php
+++ b/src/CoreBundle/Service/RequestInfoService.php
@@ -54,7 +54,10 @@ class RequestInfoService implements RequestInfoServiceInterface
      * @var bool
      */
     private $isCmsTemplateEngineEditModeCache;
-
+    /**
+     * @var bool
+     */
+    private $isPreviewModeCache;
     /**
      * @param RequestStack                 $requestStack
      * @param PortalDomainServiceInterface $portalDomainService
@@ -127,6 +130,27 @@ class RequestInfoService implements RequestInfoServiceInterface
         $this->isCmsTemplateEngineEditModeCache = false === \TGlobal::IsCMSMode() && 'true' === $request->get('__modulechooser');
 
         return $this->isCmsTemplateEngineEditModeCache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPreviewMode()
+    {
+        if (null !== $this->isPreviewModeCache) {
+            return $this->isPreviewModeCache;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return false;
+        }
+
+        // todo: `__rpeviewmode` should be the only way to enable this. Refactor all places where the preview attribute is set as `preview` instead of `__previewmode'
+        $this->isPreviewModeCache = false === \TGlobal::IsCMSMode() &&
+            ('true' === $request->get('__previewmode') || 'true' === $request->get('preview'));
+
+        return $this->isPreviewModeCache;
     }
 
     /**

--- a/src/CoreBundle/Service/RequestInfoService.php
+++ b/src/CoreBundle/Service/RequestInfoService.php
@@ -51,11 +51,11 @@ class RequestInfoService implements RequestInfoServiceInterface
      */
     private $chameleonRequestType;
     /**
-     * @var bool
+     * @var bool|null
      */
     private $isCmsTemplateEngineEditModeCache;
     /**
-     * @var bool
+     * @var bool|null
      */
     private $isPreviewModeCache;
     /**

--- a/src/CoreBundle/Service/RequestInfoService.php
+++ b/src/CoreBundle/Service/RequestInfoService.php
@@ -148,7 +148,7 @@ class RequestInfoService implements RequestInfoServiceInterface
 
         // todo: `__previewmode` should be the only way to enable this. Refactor all places where the preview attribute is set as `preview` instead of `__previewmode'
         $this->isPreviewModeCache = false === \TGlobal::IsCMSMode() &&
-            ('true' === $request->get('__previewmode') || 'true' === $request->get('preview'));
+            ('true' === $request->query->get('__previewmode') || 'true' === $request->query->get('preview'));
 
         return $this->isPreviewModeCache;
     }

--- a/src/CoreBundle/Service/RequestInfoServiceInterface.php
+++ b/src/CoreBundle/Service/RequestInfoServiceInterface.php
@@ -38,14 +38,16 @@ interface RequestInfoServiceInterface
     public function isChameleonRequestType($requestType);
 
     /**
-     * Returns true if the current request is a frontend request and the current page is the template engine.
+     * Returns true if the user is accessing a frontend page in template mode.
+     * This is used when editing spots in the backend.
      *
      * @return bool
      */
     public function isCmsTemplateEngineEditMode();
 
     /**
-     * Returns true if the current request is a frontend request AND the current page is a preview page.
+     * Returns true if the user is accessing a frontend page in preview mode.
+     * This is used when a page is previewed from the backend.
      *
      * @return bool
      */

--- a/src/CoreBundle/Service/RequestInfoServiceInterface.php
+++ b/src/CoreBundle/Service/RequestInfoServiceInterface.php
@@ -38,11 +38,18 @@ interface RequestInfoServiceInterface
     public function isChameleonRequestType($requestType);
 
     /**
-     * Returns true if the current request is a backend request AND the current page is the template engine.
+     * Returns true if the current request is a frontend request and the current page is the template engine.
      *
      * @return bool
      */
     public function isCmsTemplateEngineEditMode();
+
+    /**
+     * Returns true if the current request is a frontend request AND the current page is a preview page.
+     *
+     * @return bool
+     */
+    public function isPreviewMode();
 
     /**
      * @return bool

--- a/src/CoreBundle/Session/ChameleonSessionManager.php
+++ b/src/CoreBundle/Session/ChameleonSessionManager.php
@@ -183,6 +183,9 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
         return $this->isSessionStarting;
     }
 
+    /**
+     * @return string
+     */
     private function getCookieNameSuffix()
     {
         if (!CHAMELEON_EXTRANET_USER_IS_PORTAL_DEPENDANT) {

--- a/src/CoreBundle/Session/ChameleonSessionManager.php
+++ b/src/CoreBundle/Session/ChameleonSessionManager.php
@@ -67,14 +67,7 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
     private PortalDomainServiceInterface $portalDomainService;
 
     /**
-     * @param RequestStack                  $requestStack
-     * @param Connection                    $databaseConnection
-     * @param PDO                           $sessionPdo
-     * @param ContainerInterface            $container
-     * @param int                           $metaDataTimeout
-     * @param array                         $sessionOptions
-     * @param InputFilterUtilInterface      $inputFilterUtil
-     * @param PortalDomainServiceInterface  $portalDomainService
+     * @param array<string, mixed> $sessionOptions
      */
     public function __construct(RequestStack $requestStack, Connection $databaseConnection, PDO $sessionPdo, ContainerInterface $container, $metaDataTimeout, array $sessionOptions, InputFilterUtilInterface $inputFilterUtil, PortalDomainServiceInterface $portalDomainService)
     {

--- a/src/CoreBundle/Session/ChameleonSessionManager.php
+++ b/src/CoreBundle/Session/ChameleonSessionManager.php
@@ -32,6 +32,7 @@ use TPkgCmsSessionHandler_Decorator_Locking;
 
 class ChameleonSessionManager implements ChameleonSessionManagerInterface
 {
+    private const SESSION_BASE_NAME = 'PHPSESSID';
     /**
      * @var RequestStack
      */
@@ -139,7 +140,7 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
 
         $session = new \TPKgCmsSession($sessionStorage);
 
-        $cookieName = "PHPSESSID" . $this->getCookieNameSuffix();
+        $cookieName = self::SESSION_BASE_NAME . $this->getCookieNameSuffix();
         $session->setName($cookieName);
 
         if (false === DISABLE_SESSION_LOCKING) {

--- a/src/CoreBundle/Session/ChameleonSessionManager.php
+++ b/src/CoreBundle/Session/ChameleonSessionManager.php
@@ -60,10 +60,6 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
      */
     private $sessionOptions;
     /**
-     * @var InputFilterUtilInterface
-     */
-    private $inputFilterUtil;
-    /**
      * @var bool
      */
     private $isSessionStarting = false;
@@ -75,7 +71,7 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
      * @param int $metaDataTimeout
      * @param array<string, mixed> $sessionOptions
      */
-    public function __construct(RequestStack $requestStack, Connection $databaseConnection, PDO $sessionPdo, ContainerInterface $container, $metaDataTimeout, array $sessionOptions, InputFilterUtilInterface $inputFilterUtil, PortalDomainServiceInterface $portalDomainService, RequestInfoServiceInterface $requestInfoService, LoggerInterface $logger)
+    public function __construct(RequestStack $requestStack, Connection $databaseConnection, PDO $sessionPdo, ContainerInterface $container, $metaDataTimeout, array $sessionOptions, PortalDomainServiceInterface $portalDomainService, RequestInfoServiceInterface $requestInfoService, LoggerInterface $logger)
     {
         $this->requestStack = $requestStack;
         $this->databaseConnection = $databaseConnection;
@@ -83,7 +79,6 @@ class ChameleonSessionManager implements ChameleonSessionManagerInterface
         $this->container = $container;
         $this->metaDataTimeout = $metaDataTimeout;
         $this->sessionOptions = $sessionOptions;
-        $this->inputFilterUtil = $inputFilterUtil;
         $this->portalDomainService = $portalDomainService;
         $this->requestInfoService = $requestInfoService;
         $this->logger = $logger;


### PR DESCRIPTION
if CHAMELEON_EXTRANET_USER_IS_PORTAL_DEPENDANT is set.

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#787  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

We are now using a different session cookie for each portal if CHAMELEON_EXTRANET_USER_IS_PORTAL_DEPENDANT is set. This not only fixes the bug in #787, but also finally allows the user to be logged in to each portal separately - as it should be.
