### PR TITLE
#796: force json object for ga4 arguments, make sure array is properl…

### DIFF
--- a/src/ExternalTrackerGoogleAnalyticsBundle/Bridge/Chameleon/ExternalTracker/ExternalTrackerGoogleAnalyticsGa4.php
+++ b/src/ExternalTrackerGoogleAnalyticsBundle/Bridge/Chameleon/ExternalTracker/ExternalTrackerGoogleAnalyticsGa4.php
@@ -62,7 +62,7 @@ class ExternalTrackerGoogleAnalyticsGa4 extends TdbPkgExternalTracker
           
           %3$s
         </script>
-        ', $quotedIdentifier, json_encode($config), implode("\n", $events));
+        ', $quotedIdentifier, json_encode($config, JSON_FORCE_OBJECT), implode("\n", $events));
 
         return $lines;
     }
@@ -115,7 +115,7 @@ class ExternalTrackerGoogleAnalyticsGa4 extends TdbPkgExternalTracker
         $data = [
             'value' => (float) $event->fieldPrice,
             'currency' => $this->getActiveCurrencyCode(),
-            'items' => [
+            'items' => [[
                 'item_id' => $event->fieldArticlenumber,
                 'item_name' => $event->fieldName,
                 'item_brand' => null !== $manufacturer ? $manufacturer->fieldName : null,
@@ -123,7 +123,7 @@ class ExternalTrackerGoogleAnalyticsGa4 extends TdbPkgExternalTracker
                 'price' => (float) $event->fieldPrice,
                 'currency' => $this->getActiveCurrencyCode(),
                 'quantity' => (float) $event->fieldQuantityInUnits,
-            ]
+            ]]
         ];
 
         return sprintf('gtag("event", "%s", %s);', $gaEvent, json_encode($data));


### PR DESCRIPTION
…y provided for ga4 argument items

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#796 
| License       | MIT


