### PR TITLE
Send newsletter by name

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -6,3 +6,8 @@ strive to make code changes in minor releases in a way that preserves backwards 
 removes the compatibility layer.
 
 Other changes in this release are only minor but breaking changes. See the UPGRADE guide for information.
+
+
+### Added
+
+- Created a new Symfony command `chameleon_system:newsletter:send-newsletter` for sending a specific newsletter by name.

--- a/src/CoreBundle/private/library/classes/TCMSMemcache/TCMSMemcache.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSMemcache/TCMSMemcache.class.php
@@ -95,7 +95,7 @@ class TCMSMemcache
     public function PostInit()
     {
         if (null === $this->oMemcache) {
-//            trigger_error("couldn't get memcached instance", E_USER_ERROR);
+            trigger_error("couldn't get memcached instance", E_USER_ERROR);
         }
     }
 

--- a/src/CoreBundle/private/library/classes/TCMSMemcache/TCMSMemcache.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSMemcache/TCMSMemcache.class.php
@@ -95,7 +95,7 @@ class TCMSMemcache
     public function PostInit()
     {
         if (null === $this->oMemcache) {
-            trigger_error("couldn't get memcached instance", E_USER_ERROR);
+//            trigger_error("couldn't get memcached instance", E_USER_ERROR);
         }
     }
 

--- a/src/NewsletterBundle/Command/SendNewsletterCommand.php
+++ b/src/NewsletterBundle/Command/SendNewsletterCommand.php
@@ -42,11 +42,17 @@ class SendNewsletterCommand extends Command
              return 0;
         }
 
-        $campaign->SendNewsletter();
+        try {
+            $campaign->SendNewsletter();
+            $output->writeln('Newsletter sent successfully.');
 
-        $output->writeln('Newsletter sent successfully.');
+            return 0;
+        } catch (\Exception $exception) {
+            $output->writeln(sprintf('Exception: %s', $exception->getMessage()));
 
-        return 0;
+            return 1;
+        }
+
     }
 
 }

--- a/src/NewsletterBundle/Command/SendNewsletterCommand.php
+++ b/src/NewsletterBundle/Command/SendNewsletterCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ChameleonSystem\NewsletterBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use TdbPkgNewsletterCampaign;
+use TdbPkgNewsletterCampaignList;
+
+class SendNewsletterCommand extends Command
+{
+
+    private Connection $databaseConnection;
+
+    protected static $defaultName = 'chameleon_system:newsletter:send-newsletter';
+
+    public function __construct(Connection $databaseConnection)
+    {
+        parent::__construct();
+
+        $this->databaseConnection = $databaseConnection;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Sends a specific newsletter by name.')
+            ->addArgument('identifier', InputArgument::REQUIRED, 'Newsletter name');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $identifier = $input->getArgument('identifier');
+
+        $campaign = TdbPkgNewsletterCampaign::GetNewInstance();
+         if (false === $campaign->LoadFromField('name', $identifier)) {
+             $output->writeln('No newsletter found with the given identifier.');
+             return 0;
+        }
+
+        $campaign->SendNewsletter();
+
+        $output->writeln('Newsletter sent successfully.');
+
+        return 0;
+    }
+
+}

--- a/src/NewsletterBundle/Resources/config/services.xml
+++ b/src/NewsletterBundle/Resources/config/services.xml
@@ -41,5 +41,11 @@
             <argument type="service" id="chameleon_system_core.system_page_service" />
         </service>
 
+        <service id="chameleon_system_newsletter.command.send_newsletter"
+                 class="ChameleonSystem\NewsletterBundle\Command\SendNewsletterCommand">
+            <tag name="console.command"/>
+            <argument type="service" id="database_connection"/>
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0x for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The Newsletter Specific Sending feature is a new addition to our Chameleon application that allows you to send a specific newsletter by its name. This feature simplifies the process of sending targeted newsletters to your subscribers.

Execute the Command:
` php app/console chameleon_system:newsletter:send-newsletter "Test Newsletter"`


 
