### PR TITLE
ref #826: Improve table editor's save functionality

### DIFF
--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -17,7 +17,11 @@ var _trans_icon = '';
 var _trans_link = '';
 var _trans_password = '';
 var _trans_drag = '';
-
+let tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
+    detail: {
+        description: 'is dispatched in ExecutePostCommand' 
+    }
+});
 
 /*
  * get file usages
@@ -55,12 +59,8 @@ function ShowUsageDialog(index, _connectedDataHTML) {
 function ExecutePostCommand(command) {
     document.cmseditform.elements['module_fnc[contentmodule]'].value = command;
     if (command == 'Save') {
-        if ("undefined" != typeof CKEDITOR) {
-            $.map(CKEDITOR.instances, function (instance, instanceName) {
-                $("#" + instanceName).val(instance.getData());
-            });
-        }
-
+                document.dispatchEvent(tableEditorBeforeSaveEvent);
+        
         // remove "something changed" message, because now the data was saved
         window.onbeforeunload = function () {
         };

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -59,7 +59,7 @@ function ShowUsageDialog(index, _connectedDataHTML) {
 function ExecutePostCommand(command) {
     document.cmseditform.elements['module_fnc[contentmodule]'].value = command;
     if (command == 'Save') {
-                document.dispatchEvent(tableEditorBeforeSaveEvent);
+        document.dispatchEvent(tableEditorBeforeSaveEvent);
         
         // remove "something changed" message, because now the data was saved
         window.onbeforeunload = function () {

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -19,7 +19,7 @@ var _trans_password = '';
 var _trans_drag = '';
 const tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
     detail: {
-        description: 'is dispatched in ExecutePostCommand and SaveViaAjax' 
+        description: 'is dispatched in ExecutePostCommand and SaveViaAjax and Save'
     }
 });
 

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -478,13 +478,8 @@ function SaveFieldViaAjaxCustomCallback(customCallbackFunction) {
  */
 
 function SaveViaAjax() {
-
-    if ("undefined" != typeof CKEDITOR) {
-        $.map(CKEDITOR.instances, function (instance, instanceName) {
-            $("#" + instanceName).val(instance.getData());
-        });
-    }
-
+    document.dispatchEvent(tableEditorBeforeSaveEvent);
+                
     if (typeof (framestosave) != 'undefined' && framestosave.length > 0) {
         $.map(framestosave, function (frameToSave, index) {
             $('.itemsave:first', $('#' + frameToSave).contents()).trigger('click')

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -19,7 +19,7 @@ var _trans_password = '';
 var _trans_drag = '';
 let tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
     detail: {
-        description: 'is dispatched in ExecutePostCommand' 
+        description: 'is dispatched in ExecutePostCommand and SaveViaAjax' 
     }
 });
 

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -446,8 +446,12 @@ function ReloadMainPage() {
  * tableEditor: save edit table via ajax
  */
 function SaveViaAjaxCustomCallback(customCallbackFunction, closeAfterSave) {
-    if (customCallbackFunction == 'undefined') customCallbackFunction = SaveViaAjaxCallback;
+    if ('undefined' === customCallbackFunction) {
+        customCallbackFunction = SaveViaAjaxCallback;
+    }
 
+    document.dispatchEvent(tableEditorBeforeSaveEvent);
+    
     document.cmseditform.elements['module_fnc[contentmodule]'].value = 'ExecuteAjaxCall';
     document.cmseditform._fnc.value = 'AjaxSave';
 
@@ -465,6 +469,8 @@ function SaveFieldViaAjaxCustomCallback(customCallbackFunction) {
     if ('undefined' === customCallbackFunction) {
         customCallbackFunction = SaveViaAjaxCallback;
     }
+
+    document.dispatchEvent(tableEditorBeforeSaveEvent);
 
     document.cmseditform.elements['module_fnc[contentmodule]'].value = 'ExecuteAjaxCall';
     document.cmseditform._fnc.value = 'AjaxSaveField';
@@ -546,6 +552,8 @@ function ShowMessages(messages) {
 }
 
 function Save() {
+    document.dispatchEvent(tableEditorBeforeSaveEvent);
+    
     CHAMELEON.CORE.showProcessingModal();
     document.cmseditform.elements['module_fnc[contentmodule]'].value = 'Save';
     document.cmseditform.submit();

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -18,9 +18,6 @@ var _trans_link = '';
 var _trans_password = '';
 var _trans_drag = '';
 const tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
-    detail: {
-        description: 'is dispatched in ExecutePostCommand and SaveViaAjax and Save'
-    }
 });
 
 /*

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -17,7 +17,7 @@ var _trans_icon = '';
 var _trans_link = '';
 var _trans_password = '';
 var _trans_drag = '';
-let tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
+const tableEditorBeforeSaveEvent = new CustomEvent('tableEditorBeforeSaveEvent', {
     detail: {
         description: 'is dispatched in ExecutePostCommand and SaveViaAjax' 
     }
@@ -446,7 +446,7 @@ function ReloadMainPage() {
  * tableEditor: save edit table via ajax
  */
 function SaveViaAjaxCustomCallback(customCallbackFunction, closeAfterSave) {
-    if ('undefined' === customCallbackFunction) {
+    if (customCallbackFunction === 'undefined') {
         customCallbackFunction = SaveViaAjaxCallback;
     }
 

--- a/src/CoreBundle/Resources/public/javascript/tableEditor.js
+++ b/src/CoreBundle/Resources/public/javascript/tableEditor.js
@@ -446,7 +446,7 @@ function ReloadMainPage() {
  * tableEditor: save edit table via ajax
  */
 function SaveViaAjaxCustomCallback(customCallbackFunction, closeAfterSave) {
-    if (customCallbackFunction === 'undefined') {
+    if (typeof customCallbackFunction === 'undefined') {
         customCallbackFunction = SaveViaAjaxCallback;
     }
 

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -56,11 +56,8 @@
             CHAMELEON.CORE.CKEditor.instantiate('{{ sEditorName }}', settings);
 
             CKEDITOR.on('instanceReady', function () {
-                if (CKEDITOR.lang.de) {
-                    CKEDITOR.lang.de.common.browseServer = 'CMS Quelle wählen';
-                } else if (CKEDITOR.lang.en) {
-                CKEDITOR.lang.en.common.browseServer = 'Select CMS Source';
-                }
+                if (CKEDITOR.lang.de) CKEDITOR.lang.de.common.browseServer = 'CMS Quelle wählen';
+                else if (CKEDITOR.lang.en) CKEDITOR.lang.en.common.browseServer = 'Select CMS Source';
 
                 document.addEventListener('tableEditorBeforeSaveEvent', function(e) {
                     let data = CKEDITOR.instances['{{ sEditorName }}'].getData();

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -7,7 +7,6 @@
     </textarea>
 
     <script type="text/javascript">
-
         var editorStyleSets = '';
         editorStyleSets = {{ aEditorSettings.stylesSet|raw }};
         if (false === editorStyleSets in CKEDITOR.stylesSet.registered) {
@@ -57,8 +56,16 @@
             CHAMELEON.CORE.CKEditor.instantiate('{{ sEditorName }}', settings);
 
             CKEDITOR.on('instanceReady', function () {
-                if (CKEDITOR.lang.de) CKEDITOR.lang.de.common.browseServer = 'CMS Quelle wählen';
-                else if (CKEDITOR.lang.en) CKEDITOR.lang.en.common.browseServer = 'Select CMS Source';
+                if (CKEDITOR.lang.de) {
+                    CKEDITOR.lang.de.common.browseServer = 'CMS Quelle wählen';
+                } else if (CKEDITOR.lang.en) {
+                CKEDITOR.lang.en.common.browseServer = 'Select CMS Source';
+                }
+
+                document.addEventListener('tableEditorBeforeSaveEvent', function(e) {
+                    let data = CKEDITOR.instances[{{ sEditorName }}].getData();
+                    $('#{{ sEditorName }}').val(data);
+                });
             });
     </script>
 </div>

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -9,7 +9,7 @@
     <script type="text/javascript">
         var editorStyleSets = '';
         editorStyleSets = {{ aEditorSettings.stylesSet|raw }};
-        if (false === editorStyleSets in CKEDITOR.stylesSet.registered) {
+        if (editorStyleSets in CKEDITOR.stylesSet.registered === false) {
             {% if aEditorSettings.stylesSet %}
                 CKEDITOR.stylesSet.add({{ aEditorSettings.stylesSet|raw }}, [
                     {% for style in aStyles %}

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -9,7 +9,7 @@
     <script type="text/javascript">
         var editorStyleSets = '';
         editorStyleSets = {{ aEditorSettings.stylesSet|raw }};
-        if (editorStyleSets in CKEDITOR.stylesSet.registered === false) {
+        if (!(editorStyleSets in CKEDITOR.stylesSet.registered)) {
             {% if aEditorSettings.stylesSet %}
                 CKEDITOR.stylesSet.add({{ aEditorSettings.stylesSet|raw }}, [
                     {% for style in aStyles %}

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -60,8 +60,7 @@
                 else if (CKEDITOR.lang.en) CKEDITOR.lang.en.common.browseServer = 'Select CMS Source';
 
                 document.addEventListener('tableEditorBeforeSaveEvent', function(e) {
-                    let data = CKEDITOR.instances['{{ sEditorName }}'].getData();
-                    $('#{{ sEditorName }}').val(data);
+                    $('#{{ sEditorName }}').val(CKEDITOR.instances['{{ sEditorName }}'].getData());
                 });
             });
     </script>

--- a/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
+++ b/src/CoreBundle/Resources/views/snippets-cms/TCMSFieldWYSIWYG/cKEditor/editor.html.twig
@@ -63,7 +63,7 @@
                 }
 
                 document.addEventListener('tableEditorBeforeSaveEvent', function(e) {
-                    let data = CKEDITOR.instances[{{ sEditorName }}].getData();
+                    let data = CKEDITOR.instances['{{ sEditorName }}'].getData();
                     $('#{{ sEditorName }}').val(data);
                 });
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#826
| License       | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Introduced a new custom event `tableEditorBeforeSaveEvent` in `tableEditor.js`. This event is dispatched before saving operations, allowing other parts of the code to perform necessary actions.
- Added event listeners for `tableEditorBeforeSaveEvent` in `editor.html.twig`. These listeners retrieve data from CKEDITOR instances and set it as the value of specific elements.

> "Hoppity hop, with a skip and a jump,
> Our code takes a leap, not a single bump. 🐇
> With events so neat, and listeners in place,
> We're saving our data with style and grace. 🎉
> So here's to the changes, may they run smooth and fast,
> In the world of coding, we're having a blast! 💻🚀"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->