### PR TITLE
827 add head include modification methods to event

### DIFF
--- a/src/CoreBundle/Event/HtmlIncludeEvent.php
+++ b/src/CoreBundle/Event/HtmlIncludeEvent.php
@@ -58,9 +58,15 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
         return $this->data;
     }
 
-    public function removeDataElement(string $key): void
+    public function removeDataElement(string $key): bool
     {
+        if (!isset($this->data[$key]) {
+            return false;
+        }
+    
         unset($this->data[$key]);
+
+        return true;
     }
 
     public function updateDataElement(string $key, string $value): void
@@ -70,7 +76,6 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
 
     /**
      * @param mixed $value
-     *
      * @psalm-assert-if-true string $value
      */
     private function isInteger($value): bool

--- a/src/CoreBundle/Event/HtmlIncludeEvent.php
+++ b/src/CoreBundle/Event/HtmlIncludeEvent.php
@@ -58,13 +58,22 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
         return $this->data;
     }
 
+    public function removeDataElement(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+
+    public function updateDataElement(string $key, string $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
     /**
      * @param mixed $value
      *
-     * @return bool
      * @psalm-assert-if-true string $value
      */
-    private function isInteger($value)
+    private function isInteger($value): bool
     {
         if (true === is_numeric($value)) {
             $test = (int) $value;

--- a/src/CoreBundle/Event/HtmlIncludeEvent.php
+++ b/src/CoreBundle/Event/HtmlIncludeEvent.php
@@ -60,7 +60,7 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
 
     public function removeDataElement(string $key): bool
     {
-        if (!isset($this->data[$key]) {
+        if (!isset($this->data[$key])) {
             return false;
         }
     
@@ -71,7 +71,7 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
 
     public function updateDataElement(string $key, string $value): bool
     {
-        if (!isset($this->data[$key]) {
+        if (!isset($this->data[$key])) {
             return false;
         }
         

--- a/src/CoreBundle/Event/HtmlIncludeEvent.php
+++ b/src/CoreBundle/Event/HtmlIncludeEvent.php
@@ -69,9 +69,15 @@ class HtmlIncludeEvent extends Event implements HtmlIncludeEventInterface
         return true;
     }
 
-    public function updateDataElement(string $key, string $value): void
+    public function updateDataElement(string $key, string $value): bool
     {
+        if (!isset($this->data[$key]) {
+            return false;
+        }
+        
         $this->data[$key] = $value;
+
+        return true;
     }
 
     /**

--- a/src/CoreBundle/Event/HtmlIncludeEventInterface.php
+++ b/src/CoreBundle/Event/HtmlIncludeEventInterface.php
@@ -29,7 +29,7 @@ interface HtmlIncludeEventInterface
      */
     public function getData();
 
-    public function removeDataElement(string $key): void;
+    public function removeDataElement(string $key): bool;
 
     public function updateDataElement(string $key, string $value): void;
 }

--- a/src/CoreBundle/Event/HtmlIncludeEventInterface.php
+++ b/src/CoreBundle/Event/HtmlIncludeEventInterface.php
@@ -28,4 +28,8 @@ interface HtmlIncludeEventInterface
      * @return array
      */
     public function getData();
+
+    public function removeDataElement(string $key): void;
+
+    public function updateDataElement(string $key, string $value): void;
 }

--- a/src/CoreBundle/Event/HtmlIncludeEventInterface.php
+++ b/src/CoreBundle/Event/HtmlIncludeEventInterface.php
@@ -31,5 +31,5 @@ interface HtmlIncludeEventInterface
 
     public function removeDataElement(string $key): bool;
 
-    public function updateDataElement(string $key, string $value): void;
+    public function updateDataElement(string $key, string $value): bool;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#827
| License       | MIT
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added `removeDataElement` method to `HtmlIncludeEvent` class and `HtmlIncludeEventInterface` interface for removing specific elements from the data structure.
- Introduced `updateDataElement` method to `HtmlIncludeEvent` class and `HtmlIncludeEventInterface` interface for updating specific elements in the data structure.

> 🎉🐇
> 
> "Hopping through the code, with a swift rabbit's grace,
> 
> We've added new methods, to update and erase.
> 
> In our data structure, changes we now can trace,
> 
> Celebrate this feature, it's no small chase!" 🥕🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->