### PR TITLE
ref #780: make use of tab system names in SetTabPosition

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -1312,6 +1312,8 @@ class TCMSLogChange
             return false;
         }
 
+        $pos = (int) $pos;
+
         $query = "UPDATE `cms_tbl_field_tab` SET `position` = `position`+1 WHERE `position` > ".$pos." AND `cms_tbl_conf_id` = ".$databaseConnection->quote($tableId);
         self::_RunQuery($query, __LINE__);
 

--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -1309,6 +1309,8 @@ class TCMSLogChange
         );
         
         if (false === $pos) {
+            self::addInfoMessage("Unable to position tab ".$tabSystemName." after ".$preTabSystemName." because ".$preTabSystemName." was not found", self::INFO_MESSAGE_LEVEL_ERROR);
+            
             return false;
         }
 

--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -1262,7 +1262,7 @@ class TCMSLogChange
     }
 
     /**
-     * moves a extens behind a given extension in cms_tbl_extension.
+     * Moves an extension behind a given extension in cms_tbl_extension.
      *
      * @param int    $tableId
      * @param string $sExtensionName
@@ -1290,25 +1290,40 @@ class TCMSLogChange
     }
 
     /**
-     * moves a tab behind a given tab in cms_tbl_field_tab.
-     *
-     * @param int    $tableId
-     * @param string $sTabName
-     * @param string $sPreTabName - tabname where we want to set the new tab behind
+     * Moves a tab behind a given tab in cms_tbl_field_tab.
+     * Use the system names for the tabs.
+     * For backwards compatibility the name field is checked too.
      */
-    public static function SetTabPosition($tableId, $sTabName, $sPreTabName)
+    public static function SetTabPosition(string $tableId, string $tabSystemName, string $preTabSystemName): bool
     {
         // check position of field where we want to set the new field behind
-        $query = "SELECT * FROM `cms_tbl_field_tab` WHERE `name` = '".MySqlLegacySupport::getInstance()->real_escape_string($sPreTabName)."'";
-        $result = MySqlLegacySupport::getInstance()->query($query);
-        $posFieldRow = MySqlLegacySupport::getInstance()->fetch_assoc($result);
-        $pos = $posFieldRow['position'];
+        $databaseConnection = self::getDatabaseConnection();
 
-        $query = "UPDATE `cms_tbl_field_tab` SET `position` = `position`+1 WHERE `position` > {$pos} AND `cms_tbl_conf_id` = '{$tableId}'";
+        $nameFieldWithTranslationSuffix = self::getFieldTranslationUtil()->getTranslatedFieldName('cms_tbl_field_tab', 'name');
+        
+        $query = "SELECT `position` FROM `cms_tbl_field_tab` WHERE `cms_tbl_conf_id` = :tableId AND (".$databaseConnection->quoteIdentifier($nameFieldWithTranslationSuffix)." = :preTabName OR `systemname` = :preTabName)";
+        $pos = $databaseConnection->fetchColumn($query, [
+                'tableId' => $tableId, 
+                'preTabName' => $preTabSystemName
+                ]
+        );
+        
+        if (false === $pos) {
+            return false;
+        }
+
+        $query = "UPDATE `cms_tbl_field_tab` SET `position` = `position`+1 WHERE `position` > ".$pos." AND `cms_tbl_conf_id` = ".$databaseConnection->quote($tableId);
         self::_RunQuery($query, __LINE__);
 
-        $query = "UPDATE `cms_tbl_field_tab` SET `position` = '".MySqlLegacySupport::getInstance()->real_escape_string(($pos + 1))."' WHERE `name` = '{$sTabName}'";
+        $query = "UPDATE `cms_tbl_field_tab` 
+                     SET `position` = ".$databaseConnection->quote(($pos + 1))." 
+                   WHERE 
+                        (".$databaseConnection->quoteIdentifier($nameFieldWithTranslationSuffix)." = ".$databaseConnection->quote($tabSystemName)."
+                     OR `systemname` = ".$databaseConnection->quote($tabSystemName).") 
+                     AND `cms_tbl_conf_id` = ".$databaseConnection->quote($tableId);
         self::_RunQuery($query, __LINE__);
+
+        return true;
     }
 
     /**
@@ -1774,7 +1789,7 @@ class TCMSLogChange
         self::_RunQuery($query, __LINE__);
 
         if (null !== $sPlaceTabAfter) {
-            self::SetTabPosition($iTableId, $sOriginalTabName, $sPlaceTabAfter);
+            self::SetTabPosition($iTableId, $sTabIdentifier, $sPlaceTabAfter);
         }
 
         return $sTabId;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#780
| License       | MIT



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- The `SetTabPosition` function in `TCMSLogChange.class.php` has been enhanced. It now accepts three parameters: `$tableId`, `$tabSystemName`, and `$preTabSystemName`. This allows for more precise control over tab positioning, enabling tabs to be placed directly after a specified tab.

> 🎉🐇
> 
> Hopping through the code with glee,
> 
> A new feature we did see.
> 
> Tabs can move with such precision,
> 
> Thanks to this new addition! 🎊
<!-- end of auto-generated comment: release notes by coderabbit.ai -->