### PR TITLE
718 fix history for deletion

### DIFF
--- a/src/CoreBundle/Event/RecordChangeEvent.php
+++ b/src/CoreBundle/Event/RecordChangeEvent.php
@@ -18,6 +18,7 @@ class RecordChangeEvent extends Event
     }
 
     /**
+     * @return string
      * @deprecated use `self::getTableName()` instead
      */
     public function getTableId()

--- a/src/CoreBundle/Event/RecordChangeEvent.php
+++ b/src/CoreBundle/Event/RecordChangeEvent.php
@@ -15,6 +15,8 @@ class RecordChangeEvent extends Event
      */
     private $recordId;
 
+    private string $cmsTblConfId;
+
     /**
      * @param string $tableId
      * @param string $recordId
@@ -39,5 +41,15 @@ class RecordChangeEvent extends Event
     public function getRecordId()
     {
         return $this->recordId;
+    }
+
+    public function getCmsTblConfId(): string
+    {
+        return $this->cmsTblConfId;
+    }
+
+    public function setCmsTblConfId(string $cmsTblConfId): void
+    {
+        $this->cmsTblConfId = $cmsTblConfId;
     }
 }

--- a/src/CoreBundle/Event/RecordChangeEvent.php
+++ b/src/CoreBundle/Event/RecordChangeEvent.php
@@ -6,13 +6,15 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class RecordChangeEvent extends Event
 {
+    private string $tableName;
+    private string $recordId;
+
     private string $cmsTblConfId;
 
-    public function __construct(
-        readonly private string $tableName,
-        readonly private string $recordId,
-    )
+    public function __construct(string $tableName, string $recordId)
     {
+        $this->tableName = $tableName;
+        $this->recordId = $recordId;
     }
 
     /**

--- a/src/CoreBundle/Event/RecordChangeEvent.php
+++ b/src/CoreBundle/Event/RecordChangeEvent.php
@@ -6,33 +6,26 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class RecordChangeEvent extends Event
 {
-    /**
-     * @var string
-     */
-    private $tableId;
-    /**
-     * @var string
-     */
-    private $recordId;
-
     private string $cmsTblConfId;
 
-    /**
-     * @param string $tableId
-     * @param string $recordId
-     */
-    public function __construct($tableId, $recordId)
+    public function __construct(
+        readonly private string $tableName,
+        readonly private string $recordId,
+    )
     {
-        $this->tableId = $tableId;
-        $this->recordId = $recordId;
     }
 
     /**
-     * @return string
+     * @deprecated use `self::getTableName()` instead
      */
     public function getTableId()
     {
-        return $this->tableId;
+        return $this->tableName;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
     }
 
     /**

--- a/src/CoreBundle/EventListener/CleanupBreadcrumbAfterDeleteListener.php
+++ b/src/CoreBundle/EventListener/CleanupBreadcrumbAfterDeleteListener.php
@@ -25,6 +25,6 @@ class CleanupBreadcrumbAfterDeleteListener
             return;
         }
 
-        $breadcrumb->removeEntries($event->getTableId(), $event->getRecordId());
+        $breadcrumb->removeEntries($event->getTableId(), $event->getRecordId(), $event->getCmsTblConfId());
     }
 }

--- a/src/CoreBundle/EventListener/CleanupBreadcrumbAfterDeleteListener.php
+++ b/src/CoreBundle/EventListener/CleanupBreadcrumbAfterDeleteListener.php
@@ -25,6 +25,6 @@ class CleanupBreadcrumbAfterDeleteListener
             return;
         }
 
-        $breadcrumb->removeEntries($event->getTableId(), $event->getRecordId(), $event->getCmsTblConfId());
+        $breadcrumb->removeEntries($event->getTableName(), $event->getRecordId(), $event->getCmsTblConfId());
     }
 }

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorEndPoint.class.php
@@ -819,6 +819,7 @@ class TCMSTableEditorEndPoint
         }
 
         $event = new RecordChangeEvent($this->oTableConf->sqlData['name'], $this->sId);
+        $event->setCmsTblConfId($this->sTableId);
         $this->getEventDispatcher()->dispatch($event, CoreEvents::UPDATE_RECORD);
     }
 
@@ -1217,6 +1218,7 @@ class TCMSTableEditorEndPoint
         TCacheManager::PerformeTableChange($this->oTableConf->sqlData['name'], $sCacheTriggerID);
 
         $event = new RecordChangeEvent($this->oTableConf->sqlData['name'], $this->sId);
+        $event->setCmsTblConfId($this->sTableId);
         $this->getEventDispatcher()->dispatch($event, CoreEvents::INSERT_RECORD);
     }
 
@@ -1311,6 +1313,7 @@ class TCMSTableEditorEndPoint
         TCMSLogChange::WriteTransaction($aQuery);
 
         $event = new RecordChangeEvent($this->oTableConf->sqlData['name'], $sDeleteId);
+        $event->setCmsTblConfId($this->sTableId);
         $this->getEventDispatcher()->dispatch($event, CoreEvents::DELETE_RECORD);
 
         $this->sId = null;

--- a/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
@@ -61,10 +61,11 @@ class TCMSURLHistory
     /**
      * adds item to the breadcrumb array.
      *
-     * @param array  $aParameter - url parameters
+     * @param array $aParameter - url parameters
      * @param string $name
+     * @param callable-string|null $filterCallback
      */
-    public function AddItem($aParameter, $name = '')
+    public function AddItem($aParameter, $name = '', ?string $filterCallback = null)
     {
         $foundHistoryElementIndex = $this->getSimilarHistoryElementIndex($aParameter);
 
@@ -78,9 +79,13 @@ class TCMSURLHistory
             'name' => $name,
             'url' => $this->EncodeParameters($aParameter),
             'params' => $aParameter,
+            'filterCallback' => $filterCallback ??  '',
         );
     }
 
+    /**
+     * @note you can use "array_splice($this->aHistory, $index, 1);"
+     */
     private function removeHistoryElementByIndex(int $index): void
     {
         unset($this->aHistory[$index]);
@@ -197,6 +202,7 @@ class TCMSURLHistory
      * removes all history entries with higher index than the given one.
      *
      * @param int $id
+     * @note you can use "array_splice($this->aHistory, $id + 1);"
      */
     public function Clear($id)
     {

--- a/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
@@ -248,7 +248,7 @@ class TCMSURLHistory
      */
     public function removeEntries(string $tableId, string $entryId, string $cmsTblConfId): void
     {
-        if ( '' === $cmsTblConfId || '' === $entryId) {
+        if ('' === $cmsTblConfId || '' === $entryId) {
             return;
         }
 

--- a/src/CoreBundle/private/modules/CMSTemplateEngine/CMSTemplateEngine.class.php
+++ b/src/CoreBundle/private/modules/CMSTemplateEngine/CMSTemplateEngine.class.php
@@ -226,7 +226,7 @@ class CMSTemplateEngine extends TCMSModelBase
 
         $oMainNavigationSet = $this->IsMainNavigationSet();
         if (!$oMainNavigationSet->bMainNavigationIsSet) {
-            $sURL = PATH_CMS_CONTROLLER.'?'.str_replace('&amp;', '&', TTools::GetArrayAsURL(array('pagedef' => 'tableeditor', 'tableid' => $this->sTableID, 'id' => $this->sPageId)));//, '_nohist' => true)));
+            $sURL = PATH_CMS_CONTROLLER.'?'.str_replace('&amp;', '&', TTools::GetArrayAsURL(array('pagedef' => 'tableeditor', 'tableid' => $this->sTableID, 'id' => $this->sPageId)));
             $this->controller->HeaderURLRedirect($sURL);
         }
 

--- a/src/CoreBundle/private/modules/CMSTemplateEngine/CMSTemplateEngine.class.php
+++ b/src/CoreBundle/private/modules/CMSTemplateEngine/CMSTemplateEngine.class.php
@@ -205,14 +205,19 @@ class CMSTemplateEngine extends TCMSModelBase
             $params['sRestrictionField'] = $this->global->GetUserData('sRestrictionField');
         }
 
-        $breadcrumbTitle = TGlobal::Translate('chameleon_system_core.template_engine.breadcrumb_title_page').': '.$this->oPage->sqlData['name'];
+        $breadcrumbTitle = TGlobal::Translate('chameleon_system_core.template_engine.breadcrumb_title_page').': '.(trim($this->oPage->sqlData['name']) ?: TGlobal::Translate('chameleon_system_core.text.unnamed_record'));
 
         if ('preview_content' === $this->sMode || 'layout_selection' === $this->sMode || 'layoutlist' === $this->sMode) {
             return;
         }
 
         $breadcrumb = $this->getBreadcrumbService()->getBreadcrumb();
-        $breadcrumb->AddItem($params, $breadcrumbTitle);
+        $breadcrumb->AddItem($params, $breadcrumbTitle, join('::', ['CMSTemplateEngine', 'removeHistoryEntry']));
+    }
+
+    public static function removeHistoryEntry(array $historyEntry, string $tableId, string $entryId, string $cmsTblConfId): bool
+    {
+        return $tableId === 'cms_tpl_page' && 'templateengine' === ($historyEntry['params']['pagedef'] ?? null) && $entryId === ($historyEntry['params']['id'] ?? null);
     }
 
     public function &Execute()
@@ -221,7 +226,7 @@ class CMSTemplateEngine extends TCMSModelBase
 
         $oMainNavigationSet = $this->IsMainNavigationSet();
         if (!$oMainNavigationSet->bMainNavigationIsSet) {
-            $sURL = PATH_CMS_CONTROLLER.'?'.str_replace('&amp;', '&', TTools::GetArrayAsURL(array('pagedef' => 'tableeditor', 'tableid' => $this->sTableID, 'id' => $this->sPageId)));
+            $sURL = PATH_CMS_CONTROLLER.'?'.str_replace('&amp;', '&', TTools::GetArrayAsURL(array('pagedef' => 'tableeditor', 'tableid' => $this->sTableID, 'id' => $this->sPageId)));//, '_nohist' => true)));
             $this->controller->HeaderURLRedirect($sURL);
         }
 

--- a/src/CoreBundle/private/modules/MTTableEditor/MTTableEditor.class.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/MTTableEditor.class.php
@@ -825,7 +825,7 @@ class MTTableEditor extends TCMSModelBase
     public function Delete($bPreventRedirect = false)
     {
         $this->oTableManager->Delete();
-        //note: a symfony event removes all affected history entries, especially the current one at the top of the history stack
+        // note: the symfony event listener `CleanupBreadcrumbAfterDeleteListener` removes all affected history entries, especially the current one at the top of the history stack
 
         if (!$bPreventRedirect) {
             $inputFilterUtil = $this->getInputFilterUtil();

--- a/src/CoreBundle/private/modules/MTTableEditor/MTTableEditor.class.php
+++ b/src/CoreBundle/private/modules/MTTableEditor/MTTableEditor.class.php
@@ -825,6 +825,7 @@ class MTTableEditor extends TCMSModelBase
     public function Delete($bPreventRedirect = false)
     {
         $this->oTableManager->Delete();
+        //note: a symfony event removes all affected history entries, especially the current one at the top of the history stack
 
         if (!$bPreventRedirect) {
             $inputFilterUtil = $this->getInputFilterUtil();
@@ -859,7 +860,6 @@ class MTTableEditor extends TCMSModelBase
                         $parameter['sourceRecordID'] = $this->global->GetUserData('sourceRecordID');
                     }
 
-                    $breadcrumb->PopURL();
                     $this->controller->HeaderRedirect($parameter);
                 } else {
                     /** @var $oRestrictionTableConf TCMSTableConf */
@@ -878,13 +878,9 @@ class MTTableEditor extends TCMSModelBase
                         $parameter['sourceRecordID'] = $sourceRecordId;
                     }
 
-                    $breadcrumb->PopURL();
                     $this->controller->HeaderRedirect($parameter);
                 }
             } else {
-                // remove last item from url history
-                $breadcrumb->PopURL();
-
                 $parentURL = $breadcrumb->GetURL();
                 if (false === $parentURL) {
                     $parentURL = URL_CMS_CONTROLLER;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#718
| License       | MIT

Tests:
- add new page, delete it in the opened editor (delete button)
- add new page, fill out name and select a mandatory domain/portal, save it, and delete it (delete button)
- delete a page from the page list directly (garbage symbol)

Note: A click on a menu point resets the history

This PR fixes a function, which removes affected history entries after a deletion of a corresponding data record. 
E.g., if a page record is deleted anywhere, history links to a page editor of this page will be removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new property to track configuration IDs in record change events.
  - Enhanced breadcrumb cleanup logic to consider configuration IDs during record deletions.

- **Enhancements**
  - Updated URL history management to support filtering based on configuration IDs.

- **Refactor**
  - Improved the `removeEntries` method in URL history to utilize array filtering and callbacks for better performance and flexibility.

- **Bug Fixes**
  - Adjusted redirection logic after record deletion to ensure a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->