### PR TITLE
ref #832: copy the portal tree instead of portal navigation subtrees.

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1701162864.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1701162864.inc.php
@@ -1,0 +1,146 @@
+<h1>Build #1701162864</h1>
+<h2>Date: 2023-11-28</h2>
+<div class="changelog">
+    <ul>
+        <li>- ref #832: add preventReferenceCopy to property field ("Eigenschaften")</li>
+        <li>- ref #832: add default preventReferenceCopy=true to pkg_article_category_group table's pkg_article_category field</li>
+    </ul>
+</div>
+<?php
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'de')
+    ->setFields(
+        [
+            'help_text' => '<div class="field-name"><strong>Feldname:</strong> ZIELTABELLE oder beliebig, dann ist ein Feldkonfigurationsparameter nötig</div>
+
+            <div class="php-class"><strong>PHP Klasse:</strong> TCMSFieldPropertyTable extends TCMSFieldVarchar</div>
+
+            <div>Erzeugt eine ein-/ausklappbare Liste, in der alle Datensätze angezeigt werden, deren Parent Key dem aktuellen Datensatz entspricht.</div>
+
+            <div>Stellt eine Verbindung zu einer Tabelle her, bei der die Datensätze exklusiv verbunden werden. Das bedeutet, dass in verknüpften Datensätzen automatisch die ID des erzeugten Datensatzes (parent ID) hinterlegt wird.</div>
+
+            <div>&nbsp;</div>
+
+            <div class="important">
+            <div><strong>Wichtig:</strong> Der Name des Feldes muss exakt dem Namen der zu verknüpfenden Tabelle entsprechen.</div>
+
+            <div>In der zu verknüpfenden Tabelle muss es ein Feld vom Typ "Parent Key" geben.</div>
+
+            <div>Zusätzlich sollte als Standardwert der Name der Zieltabelle gesetzt werden.</div>
+
+            <div>Optionale Parameter beachten, falls der Name des Feldes nicht gleich dem Namen der Zieltabelle sein kann oder es in der Zieltabelle mehr als einen Parent Key auf diese Tabelle gibt und der Parent Key somit nicht eindeutig ist.</div>
+            </div>
+
+            <div>&nbsp;</div>
+
+            <div>
+            <ul>
+                <li class="parameter required head">Pflicht-Parameter:</li>
+                <li>
+                <ul>
+                    <li class="parameter required">unter bestimmten Umständen (siehe Text und Optionale Parameter)</li>
+                </ul>
+                </li>
+                <li>&nbsp;</li>
+                <li class="parameter optional head">Optionale Parameter:</li>
+                <li>
+                <ul>
+                    <li class="parameter optional"><strong>bOnlyOneRecord=true</strong> - öffnet die Zieltabelle als 1:1 Verbindung.</li>
+                    <li class="parameter optional"><strong>bOpenOnLoad=true</strong> - beim Aufruf des Editors wird die Liste bereits geöffnet angezeigt.</li>
+                    <li class="parameter optional"><strong>connectedTableName=ZIELTABELLE</strong> - der Tabellenname der Zieltabelle ohne _id. Dieser Parameter muss gesetzt werden, wenn mehrere Felder in der Tabelle mit der gleichen Zieltabelle verknüpft werden sollen. Dadurch kann ein beliebiger Feldname vergeben werden.</li>
+                    <li class="parameter optional"><strong>fieldNameInConnectedTable=NAME-DES-FELDES-IN-ZIELTABELLE</strong> - muss gesetzt werden, wenn sich in der Zieltabelle mehr als ein Parent Key auf die aktuelle Tabelle bezieht.</li>
+                    <li class="parameter optional"><strong>preventReferenceDeletion=true </strong>- Eigenschaften werden nicht gelöscht sollte der Parent gelöscht werden.</li>
+                    <li class="parameter optional"><strong>preventReferenceCopy=true </strong>- Eigenschaften werden nicht kopiert sollte der Parent kopiert werden.</li>
+                </ul>
+                </li>
+            </ul>
+            </div>
+            ',
+        ]
+    )
+    ->setWhereEquals(
+        [
+            'constname' => 'CMSFIELD_PROPERTY',
+        ]
+    );
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
+    ->setFields(
+        [
+            'help_text' => '<div class="field-name"><strong>Field name:</strong>&nbsp;TARGETTABLE or any other, then a field configuration parameter is required</div>
+
+            <div class="php-class"><strong>PHP class:</strong> TCMSFieldPropertyTable extends TCMSFieldVarchar</div>
+
+            <div>Creates a collapsing list that displays&nbsp;all records&nbsp;whose parent key corresponds to the current record.</div>
+
+            <div>Connects to a table where the records are linked exclusively.&nbsp;This means that the ID of the generated record (parent ID) is automatically stored in linked data records.</div>
+
+            <div>&nbsp;</div>
+
+            <div class="important">
+            <div><strong>Important:</strong>&nbsp;The name of the field must correspond exactly to the name of the table to be linked.</div>
+
+            <div>The table to be linked must contain a field of the type "parent key".</div>
+
+            <div>In addition, the name of the target table should be set as default value.</div>
+
+            <div>Note optional parameters, if the name of the field cannot be the same as the name of the target table, or if the target table contains more than one parent key on this table, and thus, the parent key is not unique.</div>
+            </div>
+
+            <div>&nbsp;</div>
+
+            <div>
+            <ul>
+                <li class="parameter required head">Required parameters:</li>
+                <li>
+                <ul>
+                    <li class="parameter required">under certain circumstances&nbsp;(see text and optional parameters)</li>
+                </ul>
+                </li>
+                <li>&nbsp;</li>
+                <li class="parameter optional head">Optional&nbsp;parameters:</li>
+                <li>
+                <ul>
+                    <li class="parameter optional"><strong>bOnlyOneRecord=true</strong> - opens the target table as 1:1 connection.</li>
+                    <li class="parameter optional"><strong>bOpenOnLoad=true</strong> - the list is already open when the editor is called.</li>
+                    <li class="parameter optional"><strong>connectedTableName=TARGETTABLE&nbsp;</strong>- the table name of the target table without _id. This parameter must be set, if multiple fields of the table shall be linked to the same target table. In this way one can assign any field name.</li>
+                    <li class="parameter optional"><strong>fieldNameInConnectedTable=NAME-OF-THE-FIELD-IN-TARGETTABLE</strong>&nbsp;- must be set, if more than one parent key in the target table is referenced to the current table.</li>
+                    <li class="parameter optional"><strong>preventReferenceDeletion=true </strong>- Properties will not be deleted, in case the parent is deleted.</li>
+                    <li class="parameter optional"><strong>preventReferenceCopy=true </strong>- Properties will not be copied, in case the parent is copied.</li>
+                </ul>
+                </li>
+            </ul>
+            </div>
+            ',
+        ]
+    )
+    ->setWhereEquals(
+        [
+            'constname' => 'CMSFIELD_PROPERTY',
+        ]
+    );
+TCMSLogChange::update(__LINE__, $data);
+
+
+$confId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('pkg_article_category_group'), 'pkg_article_category');
+// We need the old fieldtype_config to merge it with the new one
+$oldFieldTypeConfig = TCMSLogChange::getDatabaseConnection()->fetchOne(
+    'SELECT fieldtype_config FROM `cms_field_conf` WHERE `id` = :id',
+    ['id' => $confId]
+
+);
+if (false === $oldFieldTypeConfig) {
+    $oldFieldTypeConfig = '';
+}
+$newFieldTypeConfig = trim($oldFieldTypeConfig."\n"."preventReferenceCopy=true", "\n");
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+  ->setFields([
+      'fieldtype_config' => $newFieldTypeConfig,
+  ])
+  ->setWhereEquals([
+      'id' => $confId,
+  ])
+;
+TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1701162864.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1701162864.inc.php
@@ -3,7 +3,6 @@
 <div class="changelog">
     <ul>
         <li>- ref #832: add preventReferenceCopy to property field ("Eigenschaften")</li>
-        <li>- ref #832: add default preventReferenceCopy=true to pkg_article_category_group table's pkg_article_category field</li>
     </ul>
 </div>
 <?php
@@ -120,27 +119,4 @@ $data = TCMSLogChange::createMigrationQueryData('cms_field_type', 'en')
             'constname' => 'CMSFIELD_PROPERTY',
         ]
     );
-TCMSLogChange::update(__LINE__, $data);
-
-
-$confId = TCMSLogChange::GetTableFieldId(TCMSLogChange::GetTableId('pkg_article_category_group'), 'pkg_article_category');
-// We need the old fieldtype_config to merge it with the new one
-$oldFieldTypeConfig = TCMSLogChange::getDatabaseConnection()->fetchOne(
-    'SELECT fieldtype_config FROM `cms_field_conf` WHERE `id` = :id',
-    ['id' => $confId]
-
-);
-if (false === $oldFieldTypeConfig) {
-    $oldFieldTypeConfig = '';
-}
-$newFieldTypeConfig = trim($oldFieldTypeConfig."\n"."preventReferenceCopy=true", "\n");
-
-$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
-  ->setFields([
-      'fieldtype_config' => $newFieldTypeConfig,
-  ])
-  ->setWhereEquals([
-      'id' => $confId,
-  ])
-;
 TCMSLogChange::update(__LINE__, $data);

--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPropertyTable.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldPropertyTable.class.php
@@ -66,9 +66,9 @@ class TCMSFieldPropertyTable extends TCMSFieldVarchar
             $html .= '<input type="hidden" id="'.TGlobal::OutHTML($this->name).'" name="'.TGlobal::OutHTML($this->name).'" value="'.TGlobal::OutHTML($sPropertyTableName).'" />';
             $html .= '<div class="card">
             <div class="card-header p-1">
-                <div class="card-action" 
-                data-fieldstate="'.TGlobal::OutHTML($stateContainer->getState($this->sTableName, $this->name)).'" 
-                id="mltListControllButton'.$sEscapedName.'" 
+                <div class="card-action"
+                data-fieldstate="'.TGlobal::OutHTML($stateContainer->getState($this->sTableName, $this->name)).'"
+                id="mltListControllButton'.$sEscapedName.'"
                 onClick="setTableEditorListFieldState(this, \''.$sStateURL.'\'); '.$sOnClickEvent.'">
                 <i class="fas fa-eye"></i> '.TGlobal::OutHTML(TGlobal::Translate('chameleon_system_core.field_property.open_or_close_list')).'
                 </div>
@@ -464,6 +464,19 @@ class TCMSFieldPropertyTable extends TCMSFieldVarchar
         }
 
         return $bAllowDeleteRecordReferences;
+    }
+
+    /**
+    * Checks if its allowed to copy record references for property field.
+    */
+    public function allowCopyRecordReferences(): bool
+    {
+        $preventReferenceCopy = $this->oDefinition->GetFieldtypeConfigKey('preventReferenceCopy');
+        if ('true' === $preventReferenceCopy) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSLogChange.class.php
@@ -129,7 +129,7 @@ class TCMSLogChange
     /**
      * returns the id of a field.
      *
-     * @param int    $tableId
+     * @param string $tableId
      * @param string $sFieldName
      *
      * @return string
@@ -1300,17 +1300,17 @@ class TCMSLogChange
         $databaseConnection = self::getDatabaseConnection();
 
         $nameFieldWithTranslationSuffix = self::getFieldTranslationUtil()->getTranslatedFieldName('cms_tbl_field_tab', 'name');
-        
+
         $query = "SELECT `position` FROM `cms_tbl_field_tab` WHERE `cms_tbl_conf_id` = :tableId AND (".$databaseConnection->quoteIdentifier($nameFieldWithTranslationSuffix)." = :preTabName OR `systemname` = :preTabName)";
         $pos = $databaseConnection->fetchColumn($query, [
-                'tableId' => $tableId, 
+                'tableId' => $tableId,
                 'preTabName' => $preTabSystemName
                 ]
         );
-        
+
         if (false === $pos) {
             self::addInfoMessage("Unable to position tab ".$tabSystemName." after ".$preTabSystemName." because ".$preTabSystemName." was not found", self::INFO_MESSAGE_LEVEL_ERROR);
-            
+
             return false;
         }
 
@@ -1319,11 +1319,11 @@ class TCMSLogChange
         $query = "UPDATE `cms_tbl_field_tab` SET `position` = `position`+1 WHERE `position` > ".$pos." AND `cms_tbl_conf_id` = ".$databaseConnection->quote($tableId);
         self::_RunQuery($query, __LINE__);
 
-        $query = "UPDATE `cms_tbl_field_tab` 
-                     SET `position` = ".$databaseConnection->quote(($pos + 1))." 
-                   WHERE 
+        $query = "UPDATE `cms_tbl_field_tab`
+                     SET `position` = ".$databaseConnection->quote(($pos + 1))."
+                   WHERE
                         (".$databaseConnection->quoteIdentifier($nameFieldWithTranslationSuffix)." = ".$databaseConnection->quote($tabSystemName)."
-                     OR `systemname` = ".$databaseConnection->quote($tabSystemName).") 
+                     OR `systemname` = ".$databaseConnection->quote($tabSystemName).")
                      AND `cms_tbl_conf_id` = ".$databaseConnection->quote($tableId);
         self::_RunQuery($query, __LINE__);
 

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorManager.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorManager.class.php
@@ -148,7 +148,7 @@ class TCMSTableEditorManager
      *
      * @param string $sTableId
      * @param string $sId
-     * @param string $sLanguageID - overwrites the user language and loads the record in this language instead
+     * @param ?string $sLanguageID - overwrites the user language and loads the record in this language instead
      *
      * @return bool - returns false if the record doesn`t exist
      */

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
@@ -186,7 +186,9 @@ class TCMSTableEditorPortal extends TCMSTableEditor
         parent::OnAfterCopy();
 
         $oUser = &TCMSUser::GetActiveUser();
-        $this->linkPortalToUser($oUser);
+        if (null !== $oUser) {
+            $this->linkPortalToUser($oUser);
+        }
 
         $this->CopyNaviTree();
         $this->UnsetSessionCopiedPortalId();

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
@@ -131,11 +131,6 @@ class TCMSTableEditorPortal extends TCMSTableEditor
         $this->oTable->sqlData['is_default'] = '0';
         $this->oTable->sqlData['home_node_id'] = '';
         $this->oTable->sqlData['name'] = $this->oTable->sqlData['name'].' Copy';
-
-        //$sNewMainNodeId = $this->CreateNewMainNode();
-        //if (!is_null($sNewMainNodeId)) {
-        //    $this->oTable->sqlData['main_node_tree'] = $sNewMainNodeId;
-        //}
     }
 
     /**
@@ -193,7 +188,6 @@ class TCMSTableEditorPortal extends TCMSTableEditor
         $oUser = &TCMSUser::GetActiveUser();
         $this->linkPortalToUser($oUser);
 
-        // todo: check if we can change the method name to a more sensible name without breaking other projects
         $this->CopyNaviTree();
         $this->UnsetSessionCopiedPortalId();
         TCacheManager::PerformeTableChange('cms_user', $oUser->id);

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
@@ -483,6 +483,7 @@ class TCMSTableEditorPortal extends TCMSTableEditor
      */
     protected function CopyNodeNavigations($aSourceNode, $sTargetNodeId)
     {
+        // FIXME: This does not copy navigations that are not attached to the tree
         $navigation = TdbCmsPortalNavigation::GetNewInstance();
         if ($navigation->LoadFromField('tree_node', $aSourceNode['id'])) {
             $navigationTableConf = $navigation->GetTableConf();

--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorPortal.class.php
@@ -303,8 +303,7 @@ class TCMSTableEditorPortal extends TCMSTableEditor
             $treeTableEditor = $treeEditorManager->oTableEditor;
             $newNameValue = $treeTableEditor->oTable->sqlData['name'].$copyText;
             $urlName = $urlUtil->normalizeUrl( $treeTableEditor->oTable->sqlData['urlname'].$copyText);
-            $treeEditorManager->SaveField('name', $newNameValue, false );
-            $treeEditorManager->SaveField('urlname', $urlName, true );
+            $treeTableEditor->SaveFields(['name' => $newNameValue, 'urlname' => $urlName], false);
             $treeTableEditor->UpdateSubtreePathCache($newTreeId);
         }
 
@@ -499,7 +498,7 @@ class TCMSTableEditorPortal extends TCMSTableEditor
                 /** @var $oTableManager TCMSTableEditorManager */
                 $oTableManager = new TCMSTableEditorManager();
                 $oTableManager->Init($navigationTableConf->id, null);
-                $oTableManager->AllowEditByAll($this->bAllowEditByAll);
+                $oTableManager->AllowEditByAll(true);
                 $aDefaultData = $navigation->sqlData;
                 unset($aDefaultData['id']);
                 $aDefaultData['cms_portal_id'] = $this->sId;

--- a/src/CoreBundle/private/library/classes/TCMSstdClass/TCMSstdClass.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSstdClass/TCMSstdClass.class.php
@@ -18,7 +18,7 @@ class TCMSstdClass extends stdClass
     /**
      * record id.
      *
-     * @var int
+     * @var string
      */
     public $id = null;
 

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTreeNode.class.php
@@ -702,9 +702,10 @@ class TCMSTreeNode extends TCMSRecord implements ICmsLinkableObject
             $sPath = '/'.$sPath;
         }
         $oTableConf = $this->GetTableConf();
-        /** @var $oChildEditor TCMSTableEditorManager */
+        /** @var TCMSTableEditorManager $oChildEditor */
         $oChildEditor = new TCMSTableEditorManager();
-        $oChildEditor->Init($oTableConf->id, $this->id, $this->iLanguageId);
+        $languageId = null === $this->iLanguageId ? null : (string)$this->iLanguageId;
+        $oChildEditor->Init($oTableConf->id, $this->id, $languageId);
         $oChildEditor->AllowEditByAll(true);
         $oChildEditor->SaveField('pathcache', $sPath);
         $oChildEditor->AllowEditByAll(false);

--- a/src/CoreBundle/private/library/classes/dbobjects/TCMSTreeNode.class.php
+++ b/src/CoreBundle/private/library/classes/dbobjects/TCMSTreeNode.class.php
@@ -704,7 +704,7 @@ class TCMSTreeNode extends TCMSRecord implements ICmsLinkableObject
         $oTableConf = $this->GetTableConf();
         /** @var $oChildEditor TCMSTableEditorManager */
         $oChildEditor = new TCMSTableEditorManager();
-        $oChildEditor->Init($oTableConf->id, $this->id);
+        $oChildEditor->Init($oTableConf->id, $this->id, $this->iLanguageId);
         $oChildEditor->AllowEditByAll(true);
         $oChildEditor->SaveField('pathcache', $sPath);
         $oChildEditor->AllowEditByAll(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features / 6.2.x for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes, too).
 - Features and deprecations must be submitted against the master branch.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced portal management with the ability to copy navigation trees in multiple languages.

- **Improvements**
  - Streamlined the process of linking portals to active users.

- **Refactor**
  - Updated methods for copying portal structures to improve performance and maintainability.

- **Bug Fixes**
  - Fixed an issue in the path cache update process to correctly handle language-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->