### PR TITLE
ref #62145: fetch tracker list only once the active page becomes available to ensure that portal restrictions can be applied

### DIFF
--- a/src/ExternalTrackerBundle/objects/db/TPkgExternalTrackerList.class.php
+++ b/src/ExternalTrackerBundle/objects/db/TPkgExternalTrackerList.class.php
@@ -34,8 +34,18 @@ class TPkgExternalTrackerList extends TPkgExternalTrackerListAutoParent implemen
     public static function GetActiveInstance()
     {
         static $oInstance = null;
+        static $bTrackerListWasLoaded = false;
         if (is_null($oInstance)) {
-            $oInstance = TdbPkgExternalTrackerList::GetList();
+            $oInstance = new TdbPkgExternalTrackerList();
+        }
+        if (false === $bTrackerListWasLoaded) {
+            // we must load the items in the list only once the active page has come available. Otherwise, portal restrictions cannot apply
+            $activePage = self::getMyActivePageService()->getActivePage();
+            if (null !== $activePage) {
+                $iLanguageId = self::getMyLanguageService()->getActiveLanguageId();
+                $oInstance->Load(TdbPkgExternalTrackerList::GetDefaultQuery($iLanguageId));
+                $bTrackerListWasLoaded = true;
+            }
         }
 
         return $oInstance;


### PR DESCRIPTION
The tracker instance is generated before the active page is set. This will cause the list to only include tracker that have no portal restriction. To fix this, we load the list only once the page is available.