### PR TITLE
ref #817: Added a check in TCMSFieldModuleInstance class to ensure mo…

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldModuleInstance.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSFields/TCMSFieldModuleInstance.class.php
@@ -144,8 +144,12 @@ class TCMSFieldModuleInstance extends TCMSFieldExtendedLookup
             /** @var $this->oModuleInstance TCMSTPLModuleInstance */
             $this->oModuleInstance->Load($this->data);
             $this->oModule = new TCMSTPLModule();
-            /** @var $oModule TCMSTPLModule */
-            $this->oModule->Load($this->oModuleInstance->sqlData['cms_tpl_module_id']);
+            if (false !== $this->oModuleInstance->sqlData) {
+                $this->oModule->Load($this->oModuleInstance->sqlData['cms_tpl_module_id']);
+            } else {
+                $this->oModule = null;
+                $this->oModuleInstance = null;
+            }
         }
     }
 


### PR DESCRIPTION
…dule data exists before trying to load it, as an attempt to avoid potential errors. Now, in cases when 'sqlData' is false, it initializes oModule and oModuleInstance as null instead of trying to load them.

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#817
| License       | MIT

