### PR TITLE
ref #836: aErrorMessages is an array. The AddError message now ads ev…

### DIFF
--- a/src/CoreBundle/private/library/classes/components/imageMagick/imageMagick.class.php
+++ b/src/CoreBundle/private/library/classes/components/imageMagick/imageMagick.class.php
@@ -273,12 +273,12 @@ class imageMagick
     /**
      * adds an error message.
      *
-     * @param string $sMessage
+     * @param string $message
      */
-    protected function AddError($sMessage)
+    protected function AddError($message)
     {
         $this->bHasErrors = true;
-        $this->aErrorMessages = $sMessage;
+        $this->aErrorMessages[] = $message;
     }
 
     /**


### PR DESCRIPTION
…ery error messages to the array instead of overwriting it with the last message as string.

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#836
| License       | MIT