### PR TITLE
ref #62430: add event to get tree id map (old->new) after portal copy…

### DIFF
--- a/src/CoreBundle/CoreEvents.php
+++ b/src/CoreBundle/CoreEvents.php
@@ -72,4 +72,12 @@ final class CoreEvents
      * \ChameleonSystem\CoreBundle\Controller\ChameleonControllerInterface::FlushContentToBrowser
      */
     const FILTER_CONTENT = 'chameleon_system_core.filter_content';
+
+    /**
+     * When copying a portal a map of old tree ids to new tree ids is created.
+     * - @see TCMSPortal::dispatchTreeIdMapCompletedEvent()
+     * - @see \ChameleonSystem\CoreBundle\Event\TreeIdMapCompletedEvent
+     * This event is dispatched when the map is completed and therefore available to e. g. proprietary modules that need to fix references to tree ids.
+     */
+    const TREE_ID_MAP_COMPLETED = 'chameleon_system_core.tree_id_map_completed';
 }

--- a/src/CoreBundle/Event/TreeIdMapCompletedEvent.php
+++ b/src/CoreBundle/Event/TreeIdMapCompletedEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\CoreBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class TreeIdMapCompletedEvent extends Event
+{
+    private array $treeIdMap;
+
+    public function __construct(array $treeIdMap)
+    {
+        $this->treeIdMap = $treeIdMap;
+    }
+
+    public function getNewIdForSourceTreeId(string $sourceTreeId): ?string
+    {
+        if (array_key_exists($sourceTreeId, $this->treeIdMap)) {
+            return $this->treeIdMap[$sourceTreeId];
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | yes (adds a new event)
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This adds an event with the ids mapped from old->new for a copied portal. It is fired when the portal and all it entails is completed. This can be used to e.g. to fix any `cms_tree_id` references in a proprietary bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an event for when tree ID mapping is completed, enabling updates to proprietary module references.
- **Enhancements**
	- Introduced an event class to handle new tree ID retrieval post-mapping.
- **Refactor**
	- Updated portal editor to manage tree ID mapping and dispatch the new event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->