### PR TITLE
ref #840: dont use jquery for form submit because to send radio input…

### DIFF
--- a/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorCMSUser.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSTableEditor/TCMSTableEditorCMSUser.class.php
@@ -507,7 +507,7 @@ class TCMSTableEditorCMSUser extends TCMSTableEditor
 
         $submitButton = '';
         if (0 !== $count) {
-            $submitButton = TCMSRender::DrawButton($this->translator->trans('chameleon_system_core.table_editor_cms_user.action_copy_permissions'), "javascript:$('#copyUserRightsForm').submit();", 'far fa-clone', "mt-4 mb-1");
+            $submitButton = '<button type="submit" class="mt-4 mb-1 btn btn-primary"> <span class="far fa-clone mr-1"></span>'.$this->translator->trans('chameleon_system_core.table_editor_cms_user.action_copy_permissions').'</button>';
         }
         $sDialogContent .= $submitButton . $listContent . $submitButton."
         </form>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no
| License       | MIT

<!--
the jquery submit of the copy user rights form is not only unnecessary, but it currently prevents the copy user rights user id from being sent. That is why we should use a normal submit button.
-->

