### PR TITLE
830 fix backend breadcrumb

### DIFF
--- a/src/CoreBundle/EventListener/BackendBreadcrumbListener.php
+++ b/src/CoreBundle/EventListener/BackendBreadcrumbListener.php
@@ -79,7 +79,7 @@ class BackendBreadcrumbListener
            return false;
        }
 
-        return '/cms' === $request->getPathInfo();
+        return PATH_CMS_CONTROLLER === $request->getPathInfo();
     }
 
     private function handleBreadcrumbHistory(): void

--- a/src/CoreBundle/EventListener/BackendBreadcrumbListener.php
+++ b/src/CoreBundle/EventListener/BackendBreadcrumbListener.php
@@ -63,8 +63,23 @@ class BackendBreadcrumbListener
         if (false === $this->requestInfoService->isBackendMode()) {
             return;
         }
+        
+        if (false === $this->isValidBreadcrumbRequest()) {
+            return;
+        }
 
         $this->handleBreadcrumbHistory();
+    }
+    
+    private function isValidBreadcrumbRequest(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+       if (true === $request->isXmlHttpRequest()) {
+           return false;
+       }
+
+        return '/cms' === $request->getPathInfo();
     }
 
     private function handleBreadcrumbHistory(): void

--- a/src/CoreBundle/Service/BackendBreadcrumbService.php
+++ b/src/CoreBundle/Service/BackendBreadcrumbService.php
@@ -26,7 +26,7 @@ class BackendBreadcrumbService implements BackendBreadcrumbServiceInterface
     protected ?\TCMSURLHistory $history = null;
 
     public function __construct(
-        /** not used, could be removed */
+        /** @deprecated 7.1.6 - not used, could be removed */
         RequestStack $requestStack
     ) {
     }

--- a/src/CoreBundle/Service/BackendBreadcrumbService.php
+++ b/src/CoreBundle/Service/BackendBreadcrumbService.php
@@ -11,21 +11,24 @@
 
 namespace ChameleonSystem\CoreBundle\Service;
 
+use ChameleonSystem\CoreBundle\ServiceLocator;
+use esono\pkgCmsCache\CacheInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * manages the history object (also called "breadcrumb"), uses a cache and session object as fallback (esp. in development mode).
+ */
 class BackendBreadcrumbService implements BackendBreadcrumbServiceInterface
 {
     private const BREADCRUMB_SESSION_KEY = '_cmsurlhistory';
+    private const USER_BREADCRUMB_CACHE_TTL = 3 * 24 * 60 * 60; // 3 day (friday to monday), in seconds
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
+    protected ?\TCMSURLHistory $history = null;
 
     public function __construct(
+        /** not used, could be removed */
         RequestStack $requestStack
     ) {
-        $this->requestStack = $requestStack;
     }
 
     public function getBreadcrumb(): ?\TCMSURLHistory
@@ -35,29 +38,88 @@ class BackendBreadcrumbService implements BackendBreadcrumbServiceInterface
             return null;
         }
 
-        $breadCrumbHistory = $this->getBreadcrumbFromSession();
+        $breadCrumbHistory = $this->getBreadcrumbFromSession($backendUser);
 
         if (null === $breadCrumbHistory || false === $breadCrumbHistory->paramsParameterExists()) {
-            $this->reset();
+            if (true === $this->getCache()->isActive()) {
+                return $this->resetCache($backendUser);
+            } else {
+                return $this->resetSession();
+            }
         }
 
-        return $this->getBreadcrumbFromSession();
+        return $this->getBreadcrumbFromSession($backendUser);
     }
 
-    private function getBreadcrumbFromSession(): ?\TCMSURLHistory
+    private function getBreadcrumbFromSession(\TCMSUser $backendUser): ?\TCMSURLHistory
     {
-        if (false === isset($_SESSION[self::BREADCRUMB_SESSION_KEY])) {
-            $this->reset();
+        if (null !== $this->history) {
+            return $this->history;
         }
 
-        return $_SESSION[self::BREADCRUMB_SESSION_KEY];
+        if (true === $this->getCache()->isActive()) {
+            $key = $this->getUserCacheKey($backendUser);
+
+            $this->history = $this->getCache()->get($key);
+            if (null !== $this->history) {
+                // callback is locally not assigned yet
+                $this->setOnChangeCallback();
+
+                return $this->history;
+            }
+
+            return $this->resetCache($backendUser, $key);
+        }
+
+        return $this->resetSession();
     }
 
     /**
-     * empties the breadcrumb in the session.
+     * creates new empty breadcrumb in session object.
      */
-    private function reset(): void
+    private function resetSession(): \TCMSURLHistory
     {
-        $_SESSION[self::BREADCRUMB_SESSION_KEY] = new \TCMSURLHistory();
+        $this->history = new \TCMSURLHistory();
+        $_SESSION[self::BREADCRUMB_SESSION_KEY] = $this->history;
+
+        return $this->history;
+    }
+
+    private function getUserCacheKey(\TCMSUser $backendUser): string
+    {
+        return $this->getCache()->getKey([
+            'class' => __CLASS__,
+            'method' => __METHOD__,
+            'cms_user_id' => $backendUser->id,
+        ]);
+    }
+
+    /**
+     * creates new empty breadcrumb in cache.
+     */
+    private function resetCache(\TCMSUser $backendUser, string $key = null): \TCMSURLHistory
+    {
+        $this->history = new \TCMSURLHistory();
+        $this->setOnChangeCallback();
+        $this->setCacheValue($backendUser, $key);
+
+        return $this->history;
+    }
+
+    private function setOnChangeCallback(): void
+    {
+        $this->history->setOnChangeCallback([$this, 'setCacheValue']);
+    }
+
+    public function setCacheValue(\TCMSUser $backendUser = null, string $key = null): void
+    {
+        $backendUser ??= \TCMSUser::GetActiveUser();
+        $key ??= $this->getUserCacheKey($backendUser);
+        $this->getCache()->set($key, $this->history, ['cms_user' => $backendUser->id], self::USER_BREADCRUMB_CACHE_TTL);
+    }
+
+    private function getCache(): CacheInterface
+    {
+        return ServiceLocator::get('chameleon_system_cms_cache.cache');
     }
 }

--- a/src/CoreBundle/Service/BackendBreadcrumbService.php
+++ b/src/CoreBundle/Service/BackendBreadcrumbService.php
@@ -40,7 +40,7 @@ class BackendBreadcrumbService implements BackendBreadcrumbServiceInterface
 
         $breadCrumbHistory = $this->getBreadcrumbFromSession($backendUser);
 
-        if (null === $breadCrumbHistory || false === $breadCrumbHistory->paramsParameterExists()) {
+        if (false === $breadCrumbHistory->paramsParameterExists()) {
             if (true === $this->getCache()->isActive()) {
                 return $this->resetCache($backendUser);
             } else {
@@ -51,7 +51,7 @@ class BackendBreadcrumbService implements BackendBreadcrumbServiceInterface
         return $this->getBreadcrumbFromSession($backendUser);
     }
 
-    private function getBreadcrumbFromSession(\TCMSUser $backendUser): ?\TCMSURLHistory
+    private function getBreadcrumbFromSession(\TCMSUser $backendUser): \TCMSURLHistory
     {
         if (null !== $this->history) {
             return $this->history;

--- a/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
+++ b/src/CoreBundle/private/library/classes/TCMSURLHistory.class.php
@@ -16,10 +16,12 @@ class TCMSURLHistory
 {
     /**
      * the list of history objects.
-     *
-     * @var array
      */
-    public $aHistory = array();
+    public array $aHistory = [];
+    /**
+     * @var callable|null
+     */
+    private $onChangeCallback = null;
 
     public function __get($name)
     {
@@ -51,6 +53,8 @@ class TCMSURLHistory
             $trace[0]['file'],
             $trace[0]['line']),
             E_USER_NOTICE);
+
+        $this->update();
     }
 
     public function __isset($name)
@@ -81,6 +85,8 @@ class TCMSURLHistory
             'params' => $aParameter,
             'filterCallback' => $filterCallback ??  '',
         );
+
+        $this->update();
     }
 
     /**
@@ -91,6 +97,7 @@ class TCMSURLHistory
         unset($this->aHistory[$index]);
         // reset the index
         $this->aHistory = array_values($this->aHistory);
+        $this->update();
     }
 
     public function getSimilarHistoryElementIndex(array $newElementParameters): ?int
@@ -138,6 +145,7 @@ class TCMSURLHistory
     {
         $url = $this->GetURL();
         array_pop($this->aHistory);
+        $this->update();
 
         return $url;
     }
@@ -217,6 +225,8 @@ class TCMSURLHistory
             for ($i = $endpoint; $i > $id; --$i) {
                 unset($this->aHistory[$i]);
             }
+
+            $this->update();
         }
     }
 
@@ -226,6 +236,7 @@ class TCMSURLHistory
     public function reset()
     {
         $this->aHistory = [];
+        $this->update();
     }
 
     /**
@@ -265,5 +276,19 @@ class TCMSURLHistory
                 }
             )
         );
+
+        $this->update();
+    }
+
+    public function setOnChangeCallback(callable $onChangeCallback): void
+    {
+        $this->onChangeCallback = $onChangeCallback;
+    }
+
+    private function update(): void
+    {
+        if (true === is_callable($this->onChangeCallback)) {
+            call_user_func($this->onChangeCallback);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/chameleon-system/chameleon-system/issues/830
| License       | MIT

Usually, Symfony prevents the access on the same session object by two concurrent processes, but this does not work properly.
To have a workaround, this MR's changes uses a persistent, common shared storage (here: the internal Memcache instance) to keep the history object nearly synced.
If the cache is deactivated like in development mode, the old session storage approach is provided with the known problems in result.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced login redirection logic for a smoother user experience.
	- Introduced the ability to copy image URLs to the clipboard directly from the Media Manager.
	- Added new translations for the Media Manager's copy URL feature.
- **Enhancements**
	- Improved image cropping functionality with automatic orientation adjustment.
	- Adjusted Media Manager UI for better visibility and usability.
- **Refactor**
	- Streamlined methods related to user account links and post-login actions.
- **Style**
	- Updated Media Manager's iframe height and edit form container styling for improved layout.
- **Documentation**
	- Enhanced table column headers in Media Manager with bold styling for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->