### PR TITLE
843 backend mails with theme folder

### DIFF
--- a/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1708346253.inc.php
+++ b/src/CoreBundle/Bridge/Chameleon/Migration/Script/update-1708346253.inc.php
@@ -1,0 +1,50 @@
+<h1>Build #1708346253</h1>
+<h2>Date: 2024-02-19</h2>
+<div class="changelog">
+    - ref #843: show info/to-do message if folders in "src/extensions/objectview" could be moved into a theme folder
+</div>
+<?php
+
+use ChameleonSystem\CoreBundle\ServiceLocator;
+
+$connection = TCMSLogChange::getDatabaseConnection();
+
+$kernel = ServiceLocator::get('kernel');
+$projectPath = $kernel->getProjectDir();
+
+$extensionsPath = $projectPath.'/src/extensions/objectviews';
+if (false === file_exists($extensionsPath) || false === is_dir($extensionsPath)) {
+    return;
+}
+
+$dirs = array_diff(scandir($extensionsPath), ['.', '..']);
+if ([] === $dirs) {
+    return;
+}
+
+$backendThemeName = $connection->fetchOne('SELECT `pkg_cms_theme`.`name` FROM  `pkg_cms_theme` JOIN `cms_config` ON `pkg_cms_theme`.`id` = `cms_config`.`pkg_cms_theme_id`');
+$backendThemeName = $backendThemeName ?: '?';
+
+$themePaths = [];
+foreach ($kernel->getBundles() as $bundle) {
+    if (false === str_ends_with($bundle->getName(), 'ThemeBundle') || $bundle->getNamespace() === 'ChameleonSystem\ChameleonShopThemeBundle') {
+        continue;
+    }
+
+    $path = $bundle->getPath();
+    if (true === str_starts_with($path, $projectPath)) {
+        $path = '.'.substr($path, strlen($projectPath));
+    }
+
+    $themePaths[$bundle->getName()] = $path;
+}
+
+$output = 'Move your ./src/extensions/objectviews/{'.implode(',', $dirs).'}';
+$output .= ' into one of your preferred themes\' folder and add a snippet path to the backend\'s ("'.$backendThemeName.'") snippet-chain eventually:';
+foreach ($themePaths as $name => $path) {
+    $output .= "\n".$name.' --> '.$path.'/Resources/views/objectviews';
+}
+
+$output .= "\nNote: keep an eye on symlinks if any exist, they should be 'refreshed'";
+
+TCMSLogChange::addInfoMessage($output, TCMSLogChange::INFO_MESSAGE_LEVEL_TODO);

--- a/src/CoreBundle/private/library/classes/TViewParser/TViewPathManager.class.php
+++ b/src/CoreBundle/private/library/classes/TViewParser/TViewPathManager.class.php
@@ -134,11 +134,6 @@ class TViewPathManager implements IViewPathManager
      */
     protected function getTemplateFilePathFromTheme($sViewFileName, $sThemeSubdirectory)
     {
-        $sTemplatePath = null;
-        if (true === TGlobal::IsCMSMode()) {
-            return null;
-        }
-
         $activePortal = $this->portalDomainService->getActivePortal();
         // overwrite path with theme path if we find a portal for the current page and a theme is set
         if (null === $activePortal) {

--- a/src/CoreBundle/private/library/classes/TViewParser/TViewPathManager.class.php
+++ b/src/CoreBundle/private/library/classes/TViewParser/TViewPathManager.class.php
@@ -140,22 +140,21 @@ class TViewPathManager implements IViewPathManager
             return null;
         }
 
-        $aThemeDirectoryChain = $this->viewRendererSnippetDirectory->getBasePaths($activePortal, $sThemeSubdirectory);
-        if (0 === count($aThemeDirectoryChain)) {
+        $themeDirectoryChain = $this->viewRendererSnippetDirectory->getBasePaths($activePortal, $sThemeSubdirectory);
+        if (0 === count($themeDirectoryChain)) {
             return null;
         }
 
-        $aThemeDirectoryChain = array_reverse($aThemeDirectoryChain);
-        foreach ($aThemeDirectoryChain as $sThemeChainPath) {
-            $sFilePath = $sThemeChainPath.'/'.$sViewFileName;
+        $themeDirectoryChain = array_reverse($themeDirectoryChain);
+        foreach ($themeDirectoryChain as $themeChainPath) {
+            $filename = $themeChainPath.'/'.$sViewFileName;
 
-            if (true === file_exists($sFilePath)) {
-                $sTemplatePath = $sFilePath;
-                break;
+            if (true === file_exists($filename)) {
+                return $filename;
             }
         }
 
-        return $sTemplatePath;
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed issues  | https://github.com/chameleon-system/chameleon-system/issues/843
| License       | MIT

These changes allow to move the view resources of the legacy src/extensions/objectviews folder - mostly email templates and bundle views -  into the quite newly backend theme's resource folder.
Be sure to preserve symlink targets if there are any.
Additionally, add the preferred theme folder in the backend's snippet chain to keep the use of the resources.

For testing, follow the instructions as in the issue description to see the differences before and after (should be the same behaviour), e.g. sending email via backend. Testing other resources depends on the corresponding bundles.

Deprecation: the "src/extensions/objectviews" folder
