### PR TITLE
add image crop bundle's path into backend theme's snippet chain

### DIFF
--- a/src/ImageCropBundle/Bridge/Chameleon/Migration/Script/update-1710765740.inc.php
+++ b/src/ImageCropBundle/Bridge/Chameleon/Migration/Script/update-1710765740.inc.php
@@ -1,0 +1,12 @@
+<h1>Build #1710765740</h1>
+<h2>Date: 2024-03-18</h2>
+<div class="changelog">
+    - ref #843: add image crop bundle's path into backend theme's snippet chain
+</div>
+<?php
+
+$connection = TCMSLogChange::getDatabaseConnection();
+
+$backendThemeId = $connection->fetchOne('SELECT `pkg_cms_theme_id` FROM `cms_config`');
+
+TCMSLogChange::addToSnippetChain('@ChameleonSystem/ImageCropBundle/Resources/views', '@ChameleonSystemCoreBundle/Resources/views', [$backendThemeId]);

--- a/src/ImageCropBundle/Resources/doc/index.rst
+++ b/src/ImageCropBundle/Resources/doc/index.rst
@@ -7,9 +7,6 @@ Installation
 ------------
 
 - Add `new \ChameleonSystem\ImageCropBundle\ChameleonSystemImageCropBundle()` to the AppKernel.
-- Add a symlink inside `customer/src/extensions/snippets-cms/` pointing to `vendor/chameleon-system/chameleon-base/src/ImageCropBundle/Resources/views/snippets-cms/imageCrop`.
-To extend templates, symlinks have to be changed accordingly.
-- Add a symlink inside `customer/src/extensions/objectviews/TCMSFields` (create directory if needed) pointing to `vendor/chameleon-system/chameleon-base/src/ImageCropBundle/Resources/views/objectviews/TCMSFields/TCMSFieldMediaWithImageCrop`
 - Run CMS updates.
 - Run assets:install console command.
 - Clear Symfony cache.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed issues  | https://github.com/chameleon-system/chameleon-system/issues/843
| License       | MIT

This is an addional work for issue above, it handles the "ImageCropBundle".
The more upper levelled task is to remove the "extensions" and "framework" folder and their resouces by using the newly backend theme for example.
